### PR TITLE
chore: bring repo into compliance with repository standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Run `uv run onelake-tui --env ...`
+2. Navigate to ...
+3. Select ...
+
+## Expected Behaviour
+
+What should happen.
+
+## Actual Behaviour
+
+What actually happens. Include any error messages or unexpected output.
+
+## Environment
+
+- **OS:** (e.g. macOS 15, Ubuntu 24.04)
+- **Python version:** (e.g. 3.12.4)
+- **TUI version:** (e.g. 0.1.0)
+- **Fabric environment:** (PROD / MSIT / DXT / DAILY)
+
+## Logs
+
+<details>
+<summary>Debug log output</summary>
+
+```
+Paste relevant lines from ~/.onelake-tui/debug.log
+```
+
+</details>
+
+## Additional Context
+
+Any other relevant information (screenshots, workspace/item details, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: feature
+---
+
+## Problem Statement
+
+What problem does this feature solve? What's the current limitation or pain point?
+
+## Proposed Solution
+
+Describe the feature and how it should work.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about and why they're less suitable.
+
+## Additional Context
+
+Mockups, references, or examples from other tools that illustrate the idea.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+
+Brief summary of the changes and motivation.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / chore
+- [ ] Documentation
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `uv run pytest` passes
+- [ ] `uv run ruff check src/ tests/` passes
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] Documentation updated (if applicable)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -113,6 +113,29 @@ TUI/src/
 - Integration tests in `tests/integration/` require `az login` and real Fabric access
 - Marker `@pytest.mark.integration` for integration tests
 
+## How to Add Things
+
+### Adding a new file format preview
+
+1. In `onelake_tui/detail.py`, add an `elif` branch in `_load_preview()` matching the file extension.
+2. Read the file bytes via `self._client.dfs.read_file(ws_id, path)`.
+3. Parse/render into a string and set it on the `TextArea` widget.
+4. Add a test in `tests/` that mocks the HTTP response and verifies the preview renders.
+
+### Adding a new Fabric item type
+
+1. Add the item type constant to `onelake_client/models/fabric.py` if not already present.
+2. If the item type needs special DFS handling (e.g. different root folders), update `onelake_tui/tree.py` → `load_item()`.
+3. Update `onelake_tui/nodes.py` if a new node dataclass is needed.
+4. Add integration test coverage in `tests/integration/`.
+
+### Adding a new environment / ring
+
+1. Add a new `FabricEnvironment` instance in `onelake_client/environment.py` with the correct API and DFS hostnames.
+2. Register it in the `ENVIRONMENTS` dict in the same file.
+3. Add the `--env` choice to the CLI arg parser in `onelake_tui/app.py`.
+4. Token scopes do NOT change per ring — only hostnames differ (see [ADR-003](../docs/decisions/003-shared-token-scopes.md)).
+
 ## Decision Records
 
 Architecture decisions live in [`docs/decisions/`](../docs/decisions/). Lightweight ADR format with YAML front matter (id, title, status, date, tags). When making architectural decisions, create a new record numbered sequentially.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-06
+
+### Added
+
+- Three-panel TUI: workspace picker → item list → DFS tree + detail preview
+- Animated OneLake splash art with shimmer effect
+- Live `/` search for workspace filtering
+- Rich file preview: Markdown, JSON (NDJSON), CSV, Parquet (pyarrow), Avro (fastavro), syntax-highlighted code
+- Delta table tabbed detail: schema, data preview, transaction history, CDF
+- Schema-aware table detection for mirrored DB (`Tables/schema/table`) and lakehouse (`Tables/table`)
+- Expandable table nodes — browse raw `_delta_log/` and parquet files
+- Human-readable `onelake://` paths throughout the UI
+- Multi-environment support via `--env` flag (PROD, MSIT, DXT, DAILY)
+- 3-line status bar with keyboard shortcuts
+- Standalone async `onelake_client` library covering Fabric REST, OneLake DFS, and Delta/Iceberg metadata APIs
+- Dual-scope `DefaultAzureCredential` auth (Fabric + DFS tokens)
+- CI workflow with Python 3.11/3.12/3.13 matrix, ruff lint/format, pytest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, colour, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologising to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behaviour include:
+
+* The use of sexualised language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behaviour and will take appropriate and fair corrective action in
+response to any behaviour that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported to the project maintainer at the email address listed in their GitHub
+profile. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to OneLakeTools
+
+Thanks for your interest in contributing! This guide covers the basics.
+
+## Reporting Bugs
+
+Open an [issue](https://github.com/lmoloney/OneLakeTools/issues/new?template=bug_report.md) using the **bug report** template. Include:
+
+- Steps to reproduce
+- Expected vs actual behaviour
+- Environment details (OS, Python version, `--env` flag)
+- Relevant log output from `~/.onelake-tui/debug.log`
+
+## Suggesting Features
+
+Open an [issue](https://github.com/lmoloney/OneLakeTools/issues/new?template=feature_request.md) using the **feature request** template.
+
+## Development Setup
+
+```bash
+cd TUI
+uv sync --all-extras          # Install all deps
+uv run pytest                 # Run unit tests
+uv run ruff check src/ tests/ # Lint
+uv run ruff format src/ tests/ # Format
+uv run onelake-tui            # Launch the TUI
+```
+
+See [`docs/runbooks/local-dev-setup.md`](docs/runbooks/local-dev-setup.md) for the full setup guide.
+
+## Submitting a Pull Request
+
+1. Fork the repo and create a feature branch from `main`.
+2. Make your changes. Follow existing code style (enforced by `ruff`).
+3. Add or update tests as appropriate.
+4. Ensure `uv run pytest` and `uv run ruff check src/ tests/` pass.
+5. Update `CHANGELOG.md` under `[Unreleased]` with your changes.
+6. Open a PR against `main` using the PR template.
+
+## Code Style
+
+- Python code is formatted and linted with [Ruff](https://docs.astral.sh/ruff/).
+- Pydantic v2 models with `alias` for API field mapping (camelCase → snake_case).
+- All dynamic text in Rich/Textual `Static()` widgets must use `rich.markup.escape()`.
+- Unit tests mock HTTP responses via `pytest-httpx`.
+
+## Architecture
+
+- **`onelake_client`** is a standalone async library — no Textual dependency.
+- **`onelake_tui`** is the Textual TUI consuming the client.
+- Architecture decisions are recorded in [`docs/decisions/`](docs/decisions/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅ Current |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do not** open a public issue.
+2. Email the maintainer via the address listed on their [GitHub profile](https://github.com/lmoloney).
+3. Include a description of the vulnerability, steps to reproduce, and potential impact.
+
+You should receive an acknowledgement within 48 hours. The maintainer will work with you to understand the issue, determine its severity, and coordinate a fix before any public disclosure.
+
+## Scope
+
+This project authenticates to Microsoft Fabric using `DefaultAzureCredential`. It does **not** store credentials, tokens, or secrets. Authentication tokens are held in memory only for the duration of the session.
+
+Areas of particular security interest:
+
+- Token handling in `onelake_client/auth.py`
+- HTTP request construction in `onelake_client/_http.py`
+- Any user-supplied input rendered via Rich markup (see `rich.markup.escape()` usage)

--- a/docs/runbooks/local-dev-setup.md
+++ b/docs/runbooks/local-dev-setup.md
@@ -1,0 +1,76 @@
+# Local Development Setup
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Python | 3.11+ | [python.org](https://www.python.org/downloads/) or `brew install python` |
+| uv | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| Azure CLI | Latest | `brew install azure-cli` or [docs](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) |
+
+## Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/lmoloney/OneLakeTools.git
+cd OneLakeTools/TUI
+
+# Install dependencies
+uv sync --all-extras
+
+# Authenticate to Azure (required for Fabric API access)
+az login
+```
+
+## Running the TUI
+
+```bash
+cd TUI
+uv run onelake-tui              # PROD (default)
+uv run onelake-tui --env msit   # Microsoft internal testing
+uv run onelake-tui --env dxt    # Developer testing
+uv run onelake-tui --env daily  # Daily builds
+```
+
+## Running Tests
+
+```bash
+cd TUI
+
+# Unit tests (no Azure login required)
+uv run pytest
+
+# Integration tests (requires az login + real Fabric access)
+uv run pytest tests/integration/
+```
+
+## Linting & Formatting
+
+```bash
+cd TUI
+uv run ruff check src/ tests/    # Lint
+uv run ruff format src/ tests/   # Auto-format
+uv run ruff format --check src/ tests/  # Check format without changing
+```
+
+## Debugging
+
+Logs are written to `~/.onelake-tui/debug.log` at DEBUG level:
+
+```bash
+tail -f ~/.onelake-tui/debug.log
+```
+
+## Common Issues
+
+### `DefaultAzureCredential` fails with no credential found
+
+Run `az login` first. The TUI uses `DefaultAzureCredential` which checks the Azure CLI token cache.
+
+### Integration tests fail with 401/403
+
+Your Azure identity needs access to at least one Fabric workspace. Check that `az account show` returns the correct tenant.
+
+### `uv sync` fails on deltalake or pyarrow
+
+These packages have native extensions. Ensure you're on a supported Python version (3.11–3.13) and platform. On macOS, Xcode Command Line Tools must be installed (`xcode-select --install`).


### PR DESCRIPTION
## Description

Brings OneLakeTools into full compliance with the [repository standards](https://github.com/lmoloney/OneLakeTools) conventions.

## What changed

### Files created (8)
- `CHANGELOG.md` — Keep a Changelog format, seeded with `[0.1.0]` covering all existing features
- `CONTRIBUTING.md` — dev setup, PR workflow, code style expectations
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `SECURITY.md` — vulnerability reporting policy and scope
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` — structured feature request template
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist (tests, lint, changelog)
- `docs/runbooks/local-dev-setup.md` — prerequisites, setup, running, debugging, common issues

### Files updated (1)
- `.github/copilot-instructions.md` — added "How to Add Things" section with playbooks for: new file format preview, new Fabric item type, new environment/ring

### GitHub settings (applied separately, not in this commit)
- **Labels:** 13/13 standard labels (9 created, 4 updated, 5 GitHub defaults deleted)
- **Ruleset:** `main-protection` — admin bypass, require PR (0 approvals), block force push, restrict deletions

## Type of Change

- [x] Chore

## Checklist

- [x] No code changes — governance/docs only
- [x] `CHANGELOG.md` created with initial version
- [x] Labels and ruleset verified via `gh` CLI