### PR TITLE
feat: keyboard shortcuts overhaul — copy menu, vim nav, help screen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,15 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
+      - name: Install dependencies
+        run: cd TUI && uv sync --extra dev
+
+      - name: Lint
+        run: cd TUI && uv run ruff check src/ tests/
+
+      - name: Run unit tests
+        run: cd TUI && uv run pytest tests/ -x -q --ignore=tests/integration/
+
       - name: Build wheel and sdist
         run: cd TUI && uv build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Copy UX now uses a single `y` copy menu with four URI targets: HTTPS named, HTTPS GUID, ABFSS named, ABFSS GUID.
+- Path display now uses breadcrumb format (`Workspace / Item / path`) instead of `onelake://` display strings.
+- Help (`?`) now opens a full-screen overlay and footer visibility can be toggled with `Ctrl+F`.
+- Vim-style navigation shortcuts (`j/k/g/G`, `h/l`) are documented and surfaced consistently.
+
+### Fixed
+
+- Clipboard copy now supports platform-native command paths across macOS, Windows, and Linux with graceful fallback.
+- Delta history loading now uses bounded parallelism to reduce latency on high-version tables.
+- Parquet fallback preview now enforces memory-safe file-size limits.
+- Release publishing workflow now runs lint + unit tests before building and publishing to PyPI.
+- Documentation and splash hints are synchronized with current keybindings and URI behavior.
+
 ## [0.2.0b1] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ onelake-tui
 - Three-panel layout: workspace picker → item list → DFS tree + preview
 - Rich file preview: Markdown, JSON, CSV, Parquet, Avro, syntax-highlighted code
 - Delta table detail: schema, data preview, transaction history, CDF
-- Live workspace search, human-readable `onelake://` paths, clipboard copy
+- Live workspace search, breadcrumb path display, and copy menu (`y`) for HTTPS/ABFSS named+GUID formats
 - Multi-environment support via `--env` flag (PROD, MSIT, DXT, DAILY)
 - Keyboard-driven, zero-config (uses `az login`)
 
@@ -72,7 +72,7 @@ Each environment maps to the correct Fabric REST and OneLake DFS hostnames autom
 ```bash
 cd TUI
 uv sync --all-extras    # Install all dependencies
-uv run pytest           # Run tests (182 unit + 6 integration)
+uv run pytest           # Run tests
 uv run ruff check src/  # Lint
 uv run onelake-tui      # Launch the TUI
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | ✅ Current |
+| 0.2.x   | ✅ Current |
+| 0.1.x   | ❌ No longer supported |
 
 ## Reporting a Vulnerability
 

--- a/TUI/README.md
+++ b/TUI/README.md
@@ -31,7 +31,9 @@ Built with [Textual](https://textual.textualize.io/) and an async Python client 
 - **Schema-aware table detection** — handles both `Tables/schema/table` (mirrored DBs) and `Tables/table` (lakehouses)
 - **Live search** — press `/` to filter workspaces
 - **Multi-environment** — PROD, MSIT, DXT, DAILY via `--env` flag
-- **Human-readable paths** — `onelake://workspace/item/path` everywhere, with one-key copy (`y`, `Y`, `Ctrl+Y`)
+- **Copy menu** — press `y` to choose HTTPS/ABFSS + named/GUID URI formats
+- **Vim-friendly navigation** — `j/k/g/G` + `h/l`, with `Tab`/`Shift+Tab` still supported
+- **Toggleable footer** — `Ctrl+F` hides/shows the status bar
 - **Zero config** — uses `az login`, no service keys or config files required
 
 ## Installation
@@ -68,14 +70,16 @@ uv run onelake-tui
 | Key | Action |
 |-----|--------|
 | `↑` / `↓` | Navigate |
+| `j` / `k` | Navigate (vim-style) |
+| `g` / `G` | Jump to top / bottom |
 | `←` / `→` | Collapse/expand tree nodes |
 | `Enter` | Preview file / Expand folder |
 | `/` | Search/filter workspaces |
 | `Escape` | Close search / go back |
+| `h` / `l` | Previous/next panel |
 | `Tab` / `Shift+Tab` | Switch panels |
-| `y` | Copy `onelake://` path to clipboard |
-| `Y` (Shift) | Copy `abfss://` GUID path to clipboard |
-| `Ctrl+Y` | Copy `https://` DFS URL to clipboard |
+| `y` | Open copy menu (HTTPS/ABFSS, named/GUID) |
+| `Ctrl+F` | Toggle footer visibility |
 | `r` | Refresh |
 | `?` | Show help |
 | `q` | Quit |
@@ -144,7 +148,7 @@ tail -f ~/.onelake-tui/debug.log
 ```bash
 cd TUI
 uv sync --all-extras
-uv run pytest           # 182 unit + 6 integration tests
+uv run pytest           # Unit + integration tests
 uv run ruff check src/  # Lint
 uv run ruff format src/ # Format
 ```

--- a/TUI/README.md
+++ b/TUI/README.md
@@ -80,6 +80,7 @@ uv run onelake-tui
 | `Tab` / `Shift+Tab` | Switch panels |
 | `y` | Open copy menu (HTTPS/ABFSS, named/GUID) |
 | `Ctrl+F` | Toggle footer visibility |
+| `S` | Save SVG screenshot to current directory |
 | `r` | Refresh |
 | `?` | Show help |
 | `q` | Quit |

--- a/TUI/src/onelake_client/_http.py
+++ b/TUI/src/onelake_client/_http.py
@@ -5,6 +5,7 @@ import json
 import logging
 import random
 from collections.abc import AsyncIterator, Callable
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 import httpx
@@ -19,7 +20,10 @@ from onelake_client.exceptions import (
 
 logger = logging.getLogger("onelake_client")
 
-_USER_AGENT = "onelake-client/0.1.0"
+try:
+    _USER_AGENT = f"onelake-client/{version('onelake-tui')}"
+except PackageNotFoundError:
+    _USER_AGENT = "onelake-client/dev"
 _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {429, 500, 502, 503, 504}

--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -368,7 +368,11 @@ class OneLakeApp(App):
                 return
             uri = builder(node.data)
             if not uri:
-                self.notify("Couldn't generate a URI for the selected item", severity="warning", markup=False)
+                self.notify(
+                    "Couldn't generate a URI for the selected item",
+                    severity="warning",
+                    markup=False,
+                )
                 return
             self._copy_to_clipboard(uri, format_key.replace("_", " ").upper())
 
@@ -418,16 +422,14 @@ class OneLakeApp(App):
         """Build an HTTPS DFS URL using GUIDs."""
         if self.client is None:
             return None
-        tree = self.query_one("#tree", OneLakeTree)
-        ws_id = tree._current_workspace_id
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            return f"https://{host}/{ws_id}/{data.directory}"
+            return f"https://{host}/{data.workspace}/{data.directory}"
         elif isinstance(data, FileNode):
-            return f"https://{host}/{ws_id}/{data.path}"
+            return f"https://{host}/{data.workspace}/{data.path}"
         elif isinstance(data, TableNode):
-            return f"https://{host}/{ws_id}/{data.item_path}/Tables/{data.table_name}"
+            return f"https://{host}/{data.workspace}/{data.item_path}/Tables/{data.table_name}"
         return None
 
     def _node_to_abfss_named(self, data: object) -> str | None:
@@ -458,16 +460,14 @@ class OneLakeApp(App):
         """Build an abfss:// URI using GUIDs."""
         if self.client is None:
             return None
-        tree = self.query_one("#tree", OneLakeTree)
-        ws_id = tree._current_workspace_id
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            return f"abfss://{ws_id}@{host}/{data.directory}"
+            return f"abfss://{data.workspace}@{host}/{data.directory}"
         elif isinstance(data, FileNode):
-            return f"abfss://{ws_id}@{host}/{data.path}"
+            return f"abfss://{data.workspace}@{host}/{data.path}"
         elif isinstance(data, TableNode):
-            return f"abfss://{ws_id}@{host}/{data.item_path}/Tables/{data.table_name}"
+            return f"abfss://{data.workspace}@{host}/{data.item_path}/Tables/{data.table_name}"
         return None
 
     def action_refresh(self) -> None:

--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -8,6 +8,7 @@ import logging
 import platform
 import subprocess
 from pathlib import Path
+from urllib.parse import quote
 
 from textual import work
 from textual.app import App, ComposeResult
@@ -335,6 +336,16 @@ class OneLakeApp(App):
         normalized = path.rstrip("/")
         return normalized.split("/", 1)[-1] if "/" in normalized else normalized
 
+    @staticmethod
+    def _encode_segment(value: str) -> str:
+        """Percent-encode a single URI segment."""
+        return quote(value, safe="")
+
+    @staticmethod
+    def _encode_path(value: str) -> str:
+        """Percent-encode a URI path while preserving path separators."""
+        return quote(value, safe="/")
+
     def action_copy(self) -> None:
         """Open copy-format menu and copy the selected URI to clipboard."""
         tree = self.query_one("#tree", OneLakeTree)
@@ -385,15 +396,20 @@ class OneLakeApp(App):
         ws_name = tree._current_workspace_name or "?"
         item_name = tree._current_item.display_name if tree._current_item else "?"
         host = self.client.env.dfs_host
+        ws_name_enc = self._encode_segment(ws_name)
+        item_name_enc = self._encode_segment(item_name)
 
         if isinstance(data, FolderNode):
             rel = self._relative_item_path(data.directory)
-            return f"https://{host}/{ws_name}/{item_name}/{rel}"
+            return f"https://{host}/{ws_name_enc}/{item_name_enc}/{self._encode_path(rel)}"
         elif isinstance(data, FileNode):
             rel = self._relative_item_path(data.path)
-            return f"https://{host}/{ws_name}/{item_name}/{rel}"
+            return f"https://{host}/{ws_name_enc}/{item_name_enc}/{self._encode_path(rel)}"
         elif isinstance(data, TableNode):
-            return f"https://{host}/{ws_name}/{item_name}/Tables/{data.table_name}"
+            return (
+                f"https://{host}/{ws_name_enc}/{item_name_enc}/Tables/"
+                f"{self._encode_path(data.table_name)}"
+            )
         return None
 
     def _node_to_https_guid(self, data: object) -> str | None:
@@ -420,15 +436,20 @@ class OneLakeApp(App):
         ws_name = tree._current_workspace_name or "?"
         item_name = tree._current_item.display_name if tree._current_item else "?"
         host = self.client.env.dfs_host
+        ws_name_enc = self._encode_segment(ws_name)
+        item_name_enc = self._encode_segment(item_name)
 
         if isinstance(data, FolderNode):
             rel = self._relative_item_path(data.directory)
-            return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
+            return f"abfss://{ws_name_enc}@{host}/{item_name_enc}/{self._encode_path(rel)}"
         elif isinstance(data, FileNode):
             rel = self._relative_item_path(data.path)
-            return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
+            return f"abfss://{ws_name_enc}@{host}/{item_name_enc}/{self._encode_path(rel)}"
         elif isinstance(data, TableNode):
-            return f"abfss://{ws_name}@{host}/{item_name}/Tables/{data.table_name}"
+            return (
+                f"abfss://{ws_name_enc}@{host}/{item_name_enc}/Tables/"
+                f"{self._encode_path(data.table_name)}"
+            )
         return None
 
     def _node_to_abfss_guid(self, data: object) -> str | None:

--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -367,8 +367,10 @@ class OneLakeApp(App):
             if builder is None:
                 return
             uri = builder(node.data)
-            if uri:
-                self._copy_to_clipboard(uri, format_key.replace("_", " ").upper())
+            if not uri:
+                self.notify("Couldn't generate a URI for the selected item", severity="warning", markup=False)
+                return
+            self._copy_to_clipboard(uri, format_key.replace("_", " ").upper())
 
         self.push_screen(CopyFormatMenu(), callback=_on_format_chosen)
 

--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import platform
 import subprocess
 from pathlib import Path
 
@@ -301,11 +302,38 @@ class OneLakeApp(App):
 
     def _copy_to_clipboard(self, text: str, label: str) -> None:
         """Copy text to clipboard and show notification."""
-        try:
-            subprocess.run(["pbcopy"], input=text.encode(), check=True)
-            self.notify(f"Copied {label}: {text}", timeout=3)
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            self.notify(f"{label}: {text}", timeout=5)
+        system = platform.system()
+        commands: list[list[str]]
+        if system == "Darwin":
+            commands = [["pbcopy"]]
+        elif system == "Windows":
+            commands = [["clip.exe"]]
+        elif system == "Linux":
+            commands = [
+                ["wl-copy"],
+                ["xclip", "-selection", "clipboard"],
+                ["xsel", "--clipboard", "--input"],
+            ]
+        else:
+            commands = []
+
+        for command in commands:
+            try:
+                subprocess.run(command, input=text.encode(), check=True)
+                self.notify(f"Copied {label}: {text}", timeout=3)
+                return
+            except FileNotFoundError:
+                continue
+            except subprocess.CalledProcessError as exc:
+                logger.debug("Clipboard command failed (%s): %s", " ".join(command), exc)
+
+        self.notify(f"{label}: {text}", timeout=5)
+
+    @staticmethod
+    def _relative_item_path(path: str) -> str:
+        """Strip item prefix from a DFS path for display or named URIs."""
+        normalized = path.rstrip("/")
+        return normalized.split("/", 1)[-1] if "/" in normalized else normalized
 
     def action_copy(self) -> None:
         """Open copy-format menu and copy the selected URI to clipboard."""
@@ -340,10 +368,10 @@ class OneLakeApp(App):
         item_name = tree._current_item.display_name if tree._current_item else "?"
 
         if isinstance(data, FolderNode):
-            rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
+            rel = self._relative_item_path(data.directory)
             return f"{ws_name} / {item_name} / {rel}"
         elif isinstance(data, FileNode):
-            rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
+            rel = self._relative_item_path(data.path)
             return f"{ws_name} / {item_name} / {rel}"
         elif isinstance(data, TableNode):
             return f"{ws_name} / {item_name} / Tables / {data.table_name}"
@@ -351,16 +379,18 @@ class OneLakeApp(App):
 
     def _node_to_https_named(self, data: object) -> str | None:
         """Build an HTTPS DFS URL using workspace/item display names."""
+        if self.client is None:
+            return None
         tree = self.query_one("#tree", OneLakeTree)
         ws_name = tree._current_workspace_name or "?"
         item_name = tree._current_item.display_name if tree._current_item else "?"
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
+            rel = self._relative_item_path(data.directory)
             return f"https://{host}/{ws_name}/{item_name}/{rel}"
         elif isinstance(data, FileNode):
-            rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
+            rel = self._relative_item_path(data.path)
             return f"https://{host}/{ws_name}/{item_name}/{rel}"
         elif isinstance(data, TableNode):
             return f"https://{host}/{ws_name}/{item_name}/Tables/{data.table_name}"
@@ -368,6 +398,8 @@ class OneLakeApp(App):
 
     def _node_to_https_guid(self, data: object) -> str | None:
         """Build an HTTPS DFS URL using GUIDs."""
+        if self.client is None:
+            return None
         tree = self.query_one("#tree", OneLakeTree)
         ws_id = tree._current_workspace_id
         host = self.client.env.dfs_host
@@ -382,16 +414,18 @@ class OneLakeApp(App):
 
     def _node_to_abfss_named(self, data: object) -> str | None:
         """Build an abfss:// URI using workspace/item display names."""
+        if self.client is None:
+            return None
         tree = self.query_one("#tree", OneLakeTree)
         ws_name = tree._current_workspace_name or "?"
         item_name = tree._current_item.display_name if tree._current_item else "?"
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
+            rel = self._relative_item_path(data.directory)
             return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
         elif isinstance(data, FileNode):
-            rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
+            rel = self._relative_item_path(data.path)
             return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
         elif isinstance(data, TableNode):
             return f"abfss://{ws_name}@{host}/{item_name}/Tables/{data.table_name}"
@@ -399,6 +433,8 @@ class OneLakeApp(App):
 
     def _node_to_abfss_guid(self, data: object) -> str | None:
         """Build an abfss:// URI using GUIDs."""
+        if self.client is None:
+            return None
         tree = self.query_one("#tree", OneLakeTree)
         ws_id = tree._current_workspace_id
         host = self.client.env.dfs_host

--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -12,11 +12,13 @@ from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Header, Input, Tree
+from textual.widgets import Header, Input, OptionList, Tree
 
 from onelake_client import OneLakeClient, create_credential, get_environment
 from onelake_client.environment import DEFAULT_ENVIRONMENT, ENVIRONMENTS, FabricEnvironment
+from onelake_tui.copy_menu import CopyFormatMenu
 from onelake_tui.detail import DetailPanel
+from onelake_tui.help_screen import HelpScreen
 from onelake_tui.item_list import ItemList
 from onelake_tui.nodes import (
     FileNode,
@@ -66,11 +68,10 @@ class OneLakeApp(App):
         Binding("q", "quit", "Quit", priority=True),
         Binding("r", "refresh", "Refresh"),
         Binding("S", "screenshot", "Screenshot", show=False),
-        Binding("y", "copy_path", "Copy Path"),
-        Binding("Y", "copy_abfss", "Copy ABFSS", show=False),
-        Binding("ctrl+y", "copy_https", "Copy URL", show=False),
+        Binding("y", "copy", "Copy"),
         Binding("slash", "search", "Search", show=True, priority=True),
         Binding("question_mark", "help", "Help"),
+        Binding("ctrl+f", "toggle_footer", "Footer", show=False),
         Binding("tab", "focus_next", "Next Panel", show=False),
         Binding("shift+tab", "focus_previous", "Prev Panel", show=False),
     ]
@@ -170,7 +171,7 @@ class OneLakeApp(App):
         self.sub_title = f"{ws.display_name}{ring}"
         # Update status bar
         status = self.query_one(StatusBar)
-        status.update_path(f"onelake://{ws.display_name}")
+        status.update_path(ws.display_name)
         # Fallback: ensure identity is displayed (covers race with _probe_auth)
         if not status.identity:
             self._ensure_identity()
@@ -184,7 +185,7 @@ class OneLakeApp(App):
         detail.set_context(event.workspace_name, event.item.display_name)
         # Update status bar
         status = self.query_one(StatusBar)
-        status.update_path(f"onelake://{event.workspace_name}/{event.item.display_name}")
+        status.update_path(f"{event.workspace_name} / {event.item.display_name}")
 
     def on_tree_node_highlighted(self, event: Tree.NodeHighlighted) -> None:
         """Update detail panel when a tree node is highlighted."""
@@ -192,7 +193,7 @@ class OneLakeApp(App):
         detail = self.query_one("#detail", DetailPanel)
         status = self.query_one(StatusBar)
 
-        path = self._node_to_path(data)
+        path = self._node_display_path(data)
         if path:
             status.update_path(path)
 
@@ -227,22 +228,62 @@ class OneLakeApp(App):
             self.query_one("#items", ItemList).focus()
 
     def on_key(self, event) -> None:
-        """Handle Escape from search input."""
+        """Handle Escape, vim-style navigation (j/k/g/G), and panel switching (h/l)."""
         search = self.query_one("#search-input", Input)
+
+        # Escape dismisses search
         if event.key == "escape" and search.display and search.has_focus:
             search.display = False
             picker = self.query_one("#picker", WorkspacePicker)
             picker.clear_filter()
             picker.focus()
             event.prevent_default()
+            return
+
+        # Skip vim keys when typing in the search input
+        if search.has_focus:
+            return
+
+        focused = self.focused
+        if focused is None:
+            return
+
+        # h/l panel switching
+        if event.key == "h":
+            self.action_focus_previous()
+            event.prevent_default()
+            return
+        if event.key == "l":
+            self.action_focus_next()
+            event.prevent_default()
+            return
+
+        # j/k/g/G vim navigation on list and tree widgets
+        is_nav_widget = isinstance(focused, (OptionList, Tree))
+        if not is_nav_widget:
+            return
+
+        if event.key == "j":
+            self.simulate_key("down")
+            event.prevent_default()
+        elif event.key == "k":
+            self.simulate_key("up")
+            event.prevent_default()
+        elif event.key == "g":
+            self.simulate_key("home")
+            event.prevent_default()
+        elif event.key == "G":
+            self.simulate_key("end")
+            event.prevent_default()
 
     def action_help(self) -> None:
-        """Show keyboard shortcuts."""
-        self.notify(
-            "↑↓ Navigate  │  Enter Preview  │  / Search  │  r Refresh  │  q Quit\n"
-            "y Copy path  │  Y Copy ABFSS  │  Ctrl+Y Copy URL  │  S Screenshot",
-            timeout=10,
-        )
+        """Show full-screen help overlay."""
+        self.push_screen(HelpScreen())
+
+    def action_toggle_footer(self) -> None:
+        """Toggle the status bar visibility."""
+        status = self.query_one(StatusBar)
+        status.display = not status.display
 
     def action_screenshot(self) -> None:
         """Save an SVG screenshot to the current directory."""
@@ -266,72 +307,67 @@ class OneLakeApp(App):
         except (FileNotFoundError, subprocess.CalledProcessError):
             self.notify(f"{label}: {text}", timeout=5)
 
-    def action_copy_path(self) -> None:
-        """Copy the current OneLake path (named) to clipboard."""
+    def action_copy(self) -> None:
+        """Open copy-format menu and copy the selected URI to clipboard."""
         tree = self.query_one("#tree", OneLakeTree)
         node = tree.cursor_node
         if node is None or node.data is None:
             self.notify("No item selected", severity="warning")
             return
-        path = self._node_to_path(node.data)
-        if path:
-            self._copy_to_clipboard(path, "path")
 
-    def action_copy_abfss(self) -> None:
-        """Copy the ABFSS GUID-based path to clipboard."""
-        tree = self.query_one("#tree", OneLakeTree)
-        node = tree.cursor_node
-        if node is None or node.data is None:
-            self.notify("No item selected", severity="warning")
-            return
-        path = self._node_to_abfss(node.data)
-        if path:
-            self._copy_to_clipboard(path, "ABFSS")
+        def _on_format_chosen(format_key: str | None) -> None:
+            if format_key is None:
+                return
+            builders = {
+                "https_named": self._node_to_https_named,
+                "https_guid": self._node_to_https_guid,
+                "abfss_named": self._node_to_abfss_named,
+                "abfss_guid": self._node_to_abfss_guid,
+            }
+            builder = builders.get(format_key)
+            if builder is None:
+                return
+            uri = builder(node.data)
+            if uri:
+                self._copy_to_clipboard(uri, format_key.replace("_", " ").upper())
 
-    def action_copy_https(self) -> None:
-        """Copy the HTTPS DFS URL to clipboard."""
-        tree = self.query_one("#tree", OneLakeTree)
-        node = tree.cursor_node
-        if node is None or node.data is None:
-            self.notify("No item selected", severity="warning")
-            return
-        path = self._node_to_https(node.data)
-        if path:
-            self._copy_to_clipboard(path, "URL")
+        self.push_screen(CopyFormatMenu(), callback=_on_format_chosen)
 
-    def _node_to_path(self, data: object) -> str | None:
-        """Convert node data to a human-readable OneLake path string."""
+    def _node_display_path(self, data: object) -> str | None:
+        """Build a human-readable breadcrumb path for display (not clipboard)."""
         tree = self.query_one("#tree", OneLakeTree)
         ws_name = tree._current_workspace_name or "?"
         item_name = tree._current_item.display_name if tree._current_item else "?"
 
         if isinstance(data, FolderNode):
-            # Strip item GUID prefix to get relative path
             rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
-            return f"onelake://{ws_name}/{item_name}/{rel}"
+            return f"{ws_name} / {item_name} / {rel}"
         elif isinstance(data, FileNode):
             rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
-            return f"onelake://{ws_name}/{item_name}/{rel}"
+            return f"{ws_name} / {item_name} / {rel}"
         elif isinstance(data, TableNode):
-            return f"onelake://{ws_name}/{item_name}/Tables/{data.table_name}"
+            return f"{ws_name} / {item_name} / Tables / {data.table_name}"
         return None
 
-    def _node_to_abfss(self, data: object) -> str | None:
-        """Convert node data to an abfss:// GUID-based path."""
+    def _node_to_https_named(self, data: object) -> str | None:
+        """Build an HTTPS DFS URL using workspace/item display names."""
         tree = self.query_one("#tree", OneLakeTree)
-        ws_id = tree._current_workspace_id
+        ws_name = tree._current_workspace_name or "?"
+        item_name = tree._current_item.display_name if tree._current_item else "?"
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            return f"abfss://{ws_id}@{host}/{data.directory}"
+            rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
+            return f"https://{host}/{ws_name}/{item_name}/{rel}"
         elif isinstance(data, FileNode):
-            return f"abfss://{ws_id}@{host}/{data.path}"
+            rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
+            return f"https://{host}/{ws_name}/{item_name}/{rel}"
         elif isinstance(data, TableNode):
-            return f"abfss://{ws_id}@{host}/{data.item_path}/Tables/{data.table_name}"
+            return f"https://{host}/{ws_name}/{item_name}/Tables/{data.table_name}"
         return None
 
-    def _node_to_https(self, data: object) -> str | None:
-        """Convert node data to an https:// DFS URL."""
+    def _node_to_https_guid(self, data: object) -> str | None:
+        """Build an HTTPS DFS URL using GUIDs."""
         tree = self.query_one("#tree", OneLakeTree)
         ws_id = tree._current_workspace_id
         host = self.client.env.dfs_host
@@ -342,6 +378,37 @@ class OneLakeApp(App):
             return f"https://{host}/{ws_id}/{data.path}"
         elif isinstance(data, TableNode):
             return f"https://{host}/{ws_id}/{data.item_path}/Tables/{data.table_name}"
+        return None
+
+    def _node_to_abfss_named(self, data: object) -> str | None:
+        """Build an abfss:// URI using workspace/item display names."""
+        tree = self.query_one("#tree", OneLakeTree)
+        ws_name = tree._current_workspace_name or "?"
+        item_name = tree._current_item.display_name if tree._current_item else "?"
+        host = self.client.env.dfs_host
+
+        if isinstance(data, FolderNode):
+            rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
+            return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
+        elif isinstance(data, FileNode):
+            rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
+            return f"abfss://{ws_name}@{host}/{item_name}/{rel}"
+        elif isinstance(data, TableNode):
+            return f"abfss://{ws_name}@{host}/{item_name}/Tables/{data.table_name}"
+        return None
+
+    def _node_to_abfss_guid(self, data: object) -> str | None:
+        """Build an abfss:// URI using GUIDs."""
+        tree = self.query_one("#tree", OneLakeTree)
+        ws_id = tree._current_workspace_id
+        host = self.client.env.dfs_host
+
+        if isinstance(data, FolderNode):
+            return f"abfss://{ws_id}@{host}/{data.directory}"
+        elif isinstance(data, FileNode):
+            return f"abfss://{ws_id}@{host}/{data.path}"
+        elif isinstance(data, TableNode):
+            return f"abfss://{ws_id}@{host}/{data.item_path}/Tables/{data.table_name}"
         return None
 
     def action_refresh(self) -> None:

--- a/TUI/src/onelake_tui/copy_menu.py
+++ b/TUI/src/onelake_tui/copy_menu.py
@@ -1,0 +1,81 @@
+"""Copy-format menu — modal popup for choosing a clipboard URI format."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Label, OptionList
+from textual.widgets.option_list import Option
+
+
+class CopyFormatMenu(ModalScreen[str | None]):
+    """Modal that lets the user pick a URI format for copying.
+
+    Returns the chosen format key (e.g. ``"https_named"``) or *None* if
+    dismissed with Escape.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_menu", "Cancel", show=False),
+        Binding("1", "pick('https_named')", "HTTPS (named)", show=False),
+        Binding("2", "pick('https_guid')", "HTTPS (GUID)", show=False),
+        Binding("3", "pick('abfss_named')", "ABFSS (named)", show=False),
+        Binding("4", "pick('abfss_guid')", "ABFSS (GUID)", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    CopyFormatMenu {
+        align: center middle;
+    }
+    CopyFormatMenu > Vertical {
+        width: 40;
+        height: auto;
+        max-height: 12;
+        background: $surface;
+        border: tall $primary;
+        padding: 1 2;
+    }
+    CopyFormatMenu Label {
+        width: 100%;
+        text-align: center;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    CopyFormatMenu OptionList {
+        height: auto;
+        max-height: 6;
+        background: $surface;
+    }
+    """
+
+    # Maps option list index → format key
+    _FORMATS = [
+        ("1  HTTPS (named)", "https_named"),
+        ("2  HTTPS (GUID)", "https_guid"),
+        ("3  ABFSS (named)", "abfss_named"),
+        ("4  ABFSS (GUID)", "abfss_guid"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Copy path as…")
+            yield OptionList(
+                *[Option(label, id=key) for label, key in self._FORMATS],
+            )
+
+    def on_mount(self) -> None:
+        ol = self.query_one(OptionList)
+        ol.highlighted = 0
+        ol.focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option.id:
+            self.dismiss(event.option.id)
+
+    def action_dismiss_menu(self) -> None:
+        self.dismiss(None)
+
+    def action_pick(self, format_key: str) -> None:
+        self.dismiss(format_key)

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -149,7 +149,7 @@ class DetailPanel(VerticalScroll):
         folder_name = data.directory.split("/")[-1] if "/" in data.directory else data.directory
         self.mount(Label(f"📂 {folder_name}", classes="detail-title"))
         rel = data.directory.split("/", 1)[-1] if "/" in data.directory else data.directory
-        friendly = f"onelake://{self._workspace_name}/{self._item_name}/{rel}"
+        friendly = f"{self._workspace_name} / {self._item_name} / {rel}"
         self.mount(Static(f"[b]Path:[/b] {esc(friendly)}", classes="detail-section"))
 
     def _show_file(self, data: FileNode) -> None:
@@ -157,7 +157,7 @@ class DetailPanel(VerticalScroll):
         file_name = data.path.split("/")[-1]
         self.mount(Label(f"📄 {file_name}", classes="detail-title"))
         rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
-        friendly = f"onelake://{self._workspace_name}/{self._item_name}/{rel}"
+        friendly = f"{self._workspace_name} / {self._item_name} / {rel}"
         self.mount(Static(f"[b]Path:[/b] {esc(friendly)}", classes="detail-section"))
         self.mount(Static(f"[b]Size:[/b] {_format_size(data.size)}", classes="detail-section"))
         self._load_file_properties(data)
@@ -190,7 +190,7 @@ class DetailPanel(VerticalScroll):
         self._clear()
         self._current_table_data = data
         self.mount(Label(f"🗃️ {data.table_name}", classes="detail-title"))
-        friendly = f"onelake://{self._workspace_name}/{self._item_name}/Tables/{data.table_name}"
+        friendly = f"{self._workspace_name} / {self._item_name} / Tables / {data.table_name}"
         self.mount(Static(f"[b]Path:[/b] {esc(friendly)}", classes="detail-section"))
         self.mount(LoadingIndicator(classes="table-loading"))
         self._load_table_metadata(data)
@@ -617,7 +617,7 @@ class DetailPanel(VerticalScroll):
         ext = ("." + file_name.rsplit(".", 1)[-1]).lower() if "." in file_name else ""
         self.mount(Label(f"👁 Preview: {file_name}", classes="detail-title"))
         rel = data.path.split("/", 1)[-1] if "/" in data.path else data.path
-        friendly = f"onelake://{self._workspace_name}/{self._item_name}/{rel}"
+        friendly = f"{self._workspace_name} / {self._item_name} / {rel}"
         self.mount(
             Static(
                 f"[b]Path:[/b] {esc(friendly)}  │  [b]Size:[/b] {_format_size(data.size)}",

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import csv
 import io
@@ -36,6 +37,9 @@ NodeData = FolderNode | FileNode | TableNode | None
 
 _MAX_PREVIEW_BYTES = 512 * 1024  # 512KB text preview limit
 _MAX_BINARY_BYTES = 50 * 1024 * 1024  # 50MB binary preview limit
+_MAX_DELTA_LOG_BYTES = 2 * 1024 * 1024  # 2MB per _delta_log file
+_MAX_HISTORY_FILES = 20
+_HISTORY_FETCH_CONCURRENCY = 4
 
 _SYNTAX_LEXERS = {
     ".py": "python",
@@ -367,35 +371,56 @@ class DetailPanel(VerticalScroll):
                 [p for p in paths if p.name.endswith(".json")],
                 key=lambda p: p.name,
                 reverse=True,
-            )[:20]
+            )[:_MAX_HISTORY_FILES]
 
             commits: list[dict] = []
-            for pf in json_files:
-                raw = await self.client.dfs.read_file(data.workspace, pf.name)
+            semaphore = asyncio.Semaphore(_HISTORY_FETCH_CONCURRENCY)
+
+            async def _read_commit_file(path_info) -> list[dict]:
+                file_commits: list[dict] = []
+                async with semaphore:
+                    raw = await self.client.dfs.read_file(
+                        data.workspace,
+                        path_info.name,
+                        max_bytes=_MAX_DELTA_LOG_BYTES,
+                    )
+
                 for line in raw.decode("utf-8", errors="replace").strip().splitlines():
                     line = line.strip()
                     if not line:
                         continue
                     try:
                         obj = json.loads(line)
-                        if "commitInfo" in obj:
-                            ci = obj["commitInfo"]
-                            fname = pf.name.split("/")[-1]
-                            version = fname.replace(".json", "").lstrip("0") or "0"
-                            # Use commitInfo.timestamp (ms epoch), fall back to file lastModified
-                            ts_raw = ci.get("timestamp")
-                            if ts_raw is None and pf.last_modified:
-                                ts_raw = pf.last_modified
-                            commits.append(
-                                {
-                                    "version": version,
-                                    "timestamp": ts_raw,
-                                    "operation": ci.get("operation", ""),
-                                    "metrics": ci.get("operationMetrics", {}),
-                                }
-                            )
+                        if "commitInfo" not in obj:
+                            continue
+                        ci = obj["commitInfo"]
+                        fname = path_info.name.split("/")[-1]
+                        version = fname.replace(".json", "").lstrip("0") or "0"
+                        # Use commitInfo.timestamp (ms epoch), fall back to file lastModified
+                        ts_raw = ci.get("timestamp")
+                        if ts_raw is None and path_info.last_modified:
+                            ts_raw = path_info.last_modified
+                        file_commits.append(
+                            {
+                                "version": version,
+                                "timestamp": ts_raw,
+                                "operation": ci.get("operation", ""),
+                                "metrics": ci.get("operationMetrics", {}),
+                            }
+                        )
                     except json.JSONDecodeError:
                         continue
+                return file_commits
+
+            results = await asyncio.gather(
+                *(_read_commit_file(pf) for pf in json_files),
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, Exception):
+                    logger.debug("Skipping unreadable commit file: %s", result)
+                    continue
+                commits.extend(result)
 
             with contextlib.suppress(NoMatches):
                 self.query_one("#txn-loading").remove()
@@ -540,10 +565,21 @@ class DetailPanel(VerticalScroll):
         if not parquet_files:
             raise FileNotFoundError("No parquet files found in table directory")
 
-        # Read the first (largest) parquet file for a representative sample
+        # Read the first (largest) parquet file that stays within preview size limits.
         parquet_files.sort(key=lambda p: p.content_length or 0, reverse=True)
-        target = parquet_files[0]
-        raw = await self.client.dfs.read_file(data.workspace, target.name)
+        target = next(
+            (p for p in parquet_files if (p.content_length or 0) <= _MAX_BINARY_BYTES),
+            None,
+        )
+        if target is None:
+            raise ValueError(
+                f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
+            )
+        raw = await self.client.dfs.read_file(
+            data.workspace,
+            target.name,
+            max_bytes=_MAX_BINARY_BYTES,
+        )
         pf = pq.ParquetFile(io.BytesIO(raw))
         return pf.read_row_groups([0]).slice(0, 100)
 

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -566,7 +566,9 @@ class DetailPanel(VerticalScroll):
         if not parquet_files:
             raise FileNotFoundError("No parquet files found in table directory")
 
-        # Prefer larger known-size parquet files first, then unknown-size files.
+        # Prefer known-size parquet files first (largest to smallest), then unknown-size files.
+        # Tuple sort key is `(has_known_size, size_or_zero)` with `reverse=True`, so `True`
+        # (known size, even when zero) sorts before `False` (unknown size / None).
         parquet_files.sort(
             key=lambda p: (p.content_length is not None, p.content_length or 0),
             reverse=True,
@@ -576,10 +578,11 @@ class DetailPanel(VerticalScroll):
             for p in parquet_files
             if p.content_length is None or p.content_length <= _MAX_BINARY_BYTES
         ]
+        over_limit_msg = (
+            f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
+        )
         if not size_filtered:
-            raise ValueError(
-                f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
-            )
+            raise ValueError(over_limit_msg)
 
         for target in size_filtered:
             try:
@@ -599,9 +602,7 @@ class DetailPanel(VerticalScroll):
             pf = pq.ParquetFile(io.BytesIO(raw))
             return pf.read_row_groups([0]).slice(0, 100)
 
-        raise ValueError(
-            f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
-        )
+        raise ValueError(over_limit_msg)
 
     @work(group="detail_aux", exclusive=True)
     async def _load_cdf_preview(self) -> None:

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -28,6 +28,7 @@ from textual.widgets import (
 )
 
 from onelake_client import OneLakeClient
+from onelake_client.exceptions import FileTooLargeError
 from onelake_tui.nodes import FileNode, FolderNode, TableNode
 from onelake_tui.sprite import OneLakeSprite, get_welcome
 
@@ -565,23 +566,42 @@ class DetailPanel(VerticalScroll):
         if not parquet_files:
             raise FileNotFoundError("No parquet files found in table directory")
 
-        # Read the first (largest) parquet file that stays within preview size limits.
-        parquet_files.sort(key=lambda p: p.content_length or 0, reverse=True)
-        target = next(
-            (p for p in parquet_files if (p.content_length or 0) <= _MAX_BINARY_BYTES),
-            None,
+        # Prefer larger known-size parquet files first, then unknown-size files.
+        parquet_files.sort(
+            key=lambda p: (p.content_length is not None, p.content_length or 0),
+            reverse=True,
         )
-        if target is None:
+        size_filtered = [
+            p
+            for p in parquet_files
+            if p.content_length is None or p.content_length <= _MAX_BINARY_BYTES
+        ]
+        if not size_filtered:
             raise ValueError(
                 f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
             )
-        raw = await self.client.dfs.read_file(
-            data.workspace,
-            target.name,
-            max_bytes=_MAX_BINARY_BYTES,
+
+        for target in size_filtered:
+            try:
+                raw = await self.client.dfs.read_file(
+                    data.workspace,
+                    target.name,
+                    max_bytes=_MAX_BINARY_BYTES,
+                )
+            except FileTooLargeError:
+                logger.debug(
+                    "Skipping parquet candidate over preview limit despite "
+                    "missing/incorrect size: %s",
+                    target.name,
+                )
+                continue
+
+            pf = pq.ParquetFile(io.BytesIO(raw))
+            return pf.read_row_groups([0]).slice(0, 100)
+
+        raise ValueError(
+            f"No parquet files are within the {_format_size(_MAX_BINARY_BYTES)} preview limit"
         )
-        pf = pq.ParquetFile(io.BytesIO(raw))
-        return pf.read_row_groups([0]).slice(0, 100)
 
     @work(group="detail_aux", exclusive=True)
     async def _load_cdf_preview(self) -> None:

--- a/TUI/src/onelake_tui/help_screen.py
+++ b/TUI/src/onelake_tui/help_screen.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Vertical
+from textual.containers import Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
@@ -48,22 +48,23 @@ class HelpScreen(ModalScreen[None]):
 
     DEFAULT_CSS = """
     HelpScreen {
-        align: center middle;
+        background: $surface 70%;
     }
-    HelpScreen > Vertical {
-        width: 50;
-        height: auto;
-        max-height: 90%;
+    HelpScreen #help-root {
+        width: 1fr;
+        height: 1fr;
         background: $surface;
-        border: tall $primary;
         padding: 1 3;
     }
     HelpScreen .help-title {
         width: 100%;
-        text-align: center;
+        text-align: left;
         text-style: bold;
         color: $primary;
         margin-bottom: 1;
+    }
+    HelpScreen .help-scroll {
+        height: 1fr;
     }
     HelpScreen .help-body {
         width: 100%;
@@ -71,9 +72,10 @@ class HelpScreen(ModalScreen[None]):
     """
 
     def compose(self) -> ComposeResult:
-        with Vertical():
+        with Vertical(id="help-root"):
             yield Static("⌨️  Keyboard Shortcuts", classes="help-title")
-            yield Static(_HELP_TEXT, classes="help-body")
+            with VerticalScroll(classes="help-scroll"):
+                yield Static(_HELP_TEXT, classes="help-body")
 
     def action_dismiss_help(self) -> None:
         self.dismiss(None)

--- a/TUI/src/onelake_tui/help_screen.py
+++ b/TUI/src/onelake_tui/help_screen.py
@@ -1,0 +1,79 @@
+"""Full-screen help overlay showing all keyboard shortcuts."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+_HELP_TEXT = """\
+[b]Navigation[/b]
+  [cyan]j / ↓[/cyan]          Move down
+  [cyan]k / ↑[/cyan]          Move up
+  [cyan]g / Home[/cyan]       Go to top
+  [cyan]G / End[/cyan]        Go to bottom
+  [cyan]Enter[/cyan]          Expand / preview
+
+[b]Panels[/b]
+  [cyan]h / Shift+Tab[/cyan]  Previous panel
+  [cyan]l / Tab[/cyan]        Next panel
+
+[b]Actions[/b]
+  [cyan]y[/cyan]              Copy path (choose format)
+  [cyan]/[/cyan]              Search workspaces
+  [cyan]r[/cyan]              Refresh
+  [cyan]S[/cyan]              Screenshot (SVG)
+
+[b]Display[/b]
+  [cyan]Ctrl+f[/cyan]         Toggle footer
+  [cyan]?[/cyan]              This help screen
+
+[b]Quit[/b]
+  [cyan]q[/cyan]              Exit
+
+[dim]Press Esc, q, or ? to close[/dim]\
+"""
+
+
+class HelpScreen(ModalScreen[None]):
+    """Full-screen help overlay with all keyboard shortcuts."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss_help", "Close", show=False),
+        Binding("q", "dismiss_help", "Close", show=False),
+        Binding("question_mark", "dismiss_help", "Close", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    HelpScreen {
+        align: center middle;
+    }
+    HelpScreen > Vertical {
+        width: 50;
+        height: auto;
+        max-height: 90%;
+        background: $surface;
+        border: tall $primary;
+        padding: 1 3;
+    }
+    HelpScreen .help-title {
+        width: 100%;
+        text-align: center;
+        text-style: bold;
+        color: $primary;
+        margin-bottom: 1;
+    }
+    HelpScreen .help-body {
+        width: 100%;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Static("⌨️  Keyboard Shortcuts", classes="help-title")
+            yield Static(_HELP_TEXT, classes="help-body")
+
+    def action_dismiss_help(self) -> None:
+        self.dismiss(None)

--- a/TUI/src/onelake_tui/sprite.py
+++ b/TUI/src/onelake_tui/sprite.py
@@ -19,6 +19,7 @@ Regenerate with:
 from __future__ import annotations
 
 import re
+from importlib.metadata import PackageNotFoundError, version
 
 from textual.widgets import Static
 
@@ -102,6 +103,11 @@ _WORDMARK_LINES = [
     " ╚═════╝ ╚═╝  ╚═══╝╚══════╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝",
 ]
 
+try:
+    _APP_VERSION = version("onelake-tui")
+except PackageNotFoundError:
+    _APP_VERSION = "dev"
+
 _WORDMARK_WIDTH = max(len(ln) for ln in _WORDMARK_LINES)
 _SHIMMER_COLOR = "#E8F4FD"
 _SHIMMER_BAND = 8
@@ -181,7 +187,7 @@ def _build_welcome(shimmer_col: int | None = None) -> RenderableType:
     right[start + 9] = "[dim]Community-built terminal UI[/]"
     right[start + 10] = "[dim]for Microsoft Fabric OneLake[/]"
     right[start + 11] = "[dim]Not affiliated with Microsoft[/]"
-    right[start + 12] = "[dim]v0.1.0[/]"
+    right[start + 12] = f"[dim]v{_APP_VERSION}[/]"
 
     tbl = Table(
         show_header=False,
@@ -197,9 +203,8 @@ def _build_welcome(shimmer_col: int | None = None) -> RenderableType:
         tbl.add_row(_SPRITE_LINES[i], right[i])
 
     hints = Text.from_markup(
-        "\n  [dim]↑↓ Navigate  │  Enter Expand  │  / Search[/]"
-        "\n  [dim]Tab Switch panels  │  y Copy path"
-        "  │  Y ABFSS  │  ^Y URL  │  ? Help[/]\n"
+        "\n  [dim]↑↓ or j/k Navigate  │  Enter Expand  │  / Search[/]"
+        "\n  [dim]Tab/h/l Panels  │  g/G Top/Bottom  │  y Copy menu  │  ? Help[/]\n"
     )
 
     return Group(tbl, hints)

--- a/TUI/src/onelake_tui/status_bar.py
+++ b/TUI/src/onelake_tui/status_bar.py
@@ -10,7 +10,7 @@ from textual.widgets import Static
 class StatusBar(Static):
     """3-line status bar: path, shortcuts, and auth info."""
 
-    path: reactive[str] = reactive("onelake://", layout=False)
+    path: reactive[str] = reactive("", layout=False)
     item_count: reactive[int] = reactive(0, layout=False)
     auth_method: reactive[str] = reactive("az-cli", layout=False)
     env_name: reactive[str] = reactive("PROD", layout=False)
@@ -28,8 +28,8 @@ class StatusBar(Static):
 
         # Line 2: keyboard shortcuts (always visible)
         line2 = (
-            "↑↓ Navigate │ Enter Preview │ / Search │ Tab Panel │ "
-            "y Copy │ Y ABFSS │ ^Y URL │ q Quit"
+            "j/k Navigate │ g/G Top/Bottom │ Enter Preview │ / Search │ "
+            "h/l Tab Panels │ y Copy │ ^F Footer │ q Quit"
         )
 
         # Line 3: auth + identity + environment

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -114,7 +114,7 @@ async def test_action_help_notifies():
 
 @pytest.mark.asyncio
 async def test_copy_path_no_selection():
-    """Mount app. Call action_copy_path() with no tree selection.
+    """Mount app. Call action_copy() with no tree selection.
     Should show a warning notification without crashing.
     """
     app, _ = _create_app_harness()
@@ -126,8 +126,8 @@ async def test_copy_path_no_selection():
         # Verify tree has no cursor node selected
         assert tree.cursor_node is None or tree.cursor_node.data is None
 
-        # Call action_copy_path — should show warning but not crash
-        app.action_copy_path()
+        # Call action_copy — should show warning but not crash
+        app.action_copy()
         await pilot.pause()
 
 
@@ -136,8 +136,8 @@ async def test_copy_path_no_selection():
 
 @pytest.mark.asyncio
 async def test_node_to_path_folder():
-    """Mount app. Set tree context. Convert FolderNode to path.
-    Verify format: onelake://WsName/ItemName/relative/path
+    """Mount app. Set tree context. Convert FolderNode to display path.
+    Verify format: WsName / ItemName / relative/path
     """
     app, _ = _create_app_harness()
 
@@ -161,8 +161,8 @@ async def test_node_to_path_folder():
             directory="item-guid/Files/subfolder",  # item GUID prefix should be stripped
         )
 
-        result = app._node_to_path(folder_node)
-        assert result == "onelake://MyWorkspace/MyLakehouse/Files/subfolder"
+        result = app._node_display_path(folder_node)
+        assert result == "MyWorkspace / MyLakehouse / Files/subfolder"
 
 
 # ── 6. test_node_to_path_file ────────────────────────────────────────
@@ -170,8 +170,8 @@ async def test_node_to_path_folder():
 
 @pytest.mark.asyncio
 async def test_node_to_path_file():
-    """Mount app. Set tree context. Convert FileNode to path.
-    Verify format: onelake://WsName/ItemName/path/to/file
+    """Mount app. Set tree context. Convert FileNode to display path.
+    Verify format: WsName / ItemName / path/to/file
     """
     app, _ = _create_app_harness()
 
@@ -195,8 +195,8 @@ async def test_node_to_path_file():
             size=2048,
         )
 
-        result = app._node_to_path(file_node)
-        assert result == "onelake://MyWorkspace/MyLakehouse/Files/data.csv"
+        result = app._node_display_path(file_node)
+        assert result == "MyWorkspace / MyLakehouse / Files/data.csv"
 
 
 # ── 7. test_node_to_path_table ───────────────────────────────────────
@@ -204,8 +204,8 @@ async def test_node_to_path_file():
 
 @pytest.mark.asyncio
 async def test_node_to_path_table():
-    """Mount app. Set tree context. Convert TableNode to path.
-    Verify format includes Tables/: onelake://WsName/ItemName/Tables/table_name
+    """Mount app. Set tree context. Convert TableNode to display path.
+    Verify format: WsName / ItemName / Tables / table_name
     """
     app, _ = _create_app_harness()
 
@@ -229,8 +229,8 @@ async def test_node_to_path_table():
             table_name="dbo/my_table",
         )
 
-        result = app._node_to_path(table_node)
-        assert result == "onelake://MyWorkspace/MyLakehouse/Tables/dbo/my_table"
+        result = app._node_display_path(table_node)
+        assert result == "MyWorkspace / MyLakehouse / Tables / dbo/my_table"
 
 
 # ── 8. test_node_to_abfss_folder ────────────────────────────────────
@@ -262,7 +262,7 @@ async def test_node_to_abfss_folder():
             directory="item-guid/Files/subfolder",
         )
 
-        result = app._node_to_abfss(folder_node)
+        result = app._node_to_abfss_guid(folder_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"abfss://ws-guid-123@{host}/item-guid/Files/subfolder"
 
@@ -296,7 +296,7 @@ async def test_node_to_https_file():
             size=2048,
         )
 
-        result = app._node_to_https(file_node)
+        result = app._node_to_https_guid(file_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"https://{host}/ws-guid-123/item-guid/Files/data.csv"
 
@@ -306,7 +306,7 @@ async def test_node_to_https_file():
 
 @pytest.mark.asyncio
 async def test_node_to_path_none_data():
-    """Mount app. Call _node_to_path() with unsupported data type.
+    """Mount app. Call _node_display_path() with unsupported data type.
     Verify it returns None without crashing.
     """
     app, _ = _create_app_harness()
@@ -315,15 +315,15 @@ async def test_node_to_path_none_data():
         await pilot.pause()
 
         # Call with unsupported type
-        result = app._node_to_path("unsupported")
+        result = app._node_display_path("unsupported")
         assert result is None
 
         # Also test with an integer
-        result = app._node_to_path(42)
+        result = app._node_display_path(42)
         assert result is None
 
         # Test with None
-        result = app._node_to_path(None)
+        result = app._node_display_path(None)
         assert result is None
 
 
@@ -371,7 +371,7 @@ async def test_node_to_https_table():
             table_name="dbo/my_table",
         )
 
-        result = app._node_to_https(table_node)
+        result = app._node_to_https_guid(table_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"https://{host}/ws-guid-123/item-guid/Tables/dbo/my_table"
 
@@ -402,7 +402,7 @@ async def test_node_to_abfss_file():
             size=2048,
         )
 
-        result = app._node_to_abfss(file_node)
+        result = app._node_to_abfss_guid(file_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"abfss://ws-guid-123@{host}/item-guid/Files/data.csv"
 
@@ -433,6 +433,6 @@ async def test_node_to_abfss_table():
             table_name="dbo/my_table",
         )
 
-        result = app._node_to_abfss(table_node)
+        result = app._node_to_abfss_guid(table_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"abfss://ws-guid-123@{host}/item-guid/Tables/dbo/my_table"

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -561,7 +561,7 @@ async def test_uri_builders_return_none_without_client():
 
 
 @pytest.mark.asyncio
-async def test_named_uri_builders_percent_encode_workspace_item_and_paths():
+async def test_named_uri_builders_encode_special_characters():
     """Named URI builders should percent-encode unsafe chars in workspace/item/path segments."""
     app, _ = _create_app_harness()
 

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -561,6 +561,38 @@ async def test_uri_builders_return_none_without_client():
 
 
 @pytest.mark.asyncio
+async def test_named_uri_builders_percent_encode_workspace_item_and_paths():
+    """Named URI builders should percent-encode unsafe chars in workspace/item/path segments."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("#tree", OneLakeTree)
+        tree._current_workspace_name = "My Workspace/West"
+        tree._current_workspace_id = "ws-guid-123"
+        tree._current_item = Item(id="item-guid", display_name="Lake#1", type="Lakehouse")
+
+        file_node = FileNode(
+            workspace="ws-guid-123",
+            path="item-guid/Files/raw data/file #1.csv",
+            size=1,
+        )
+        table_node = TableNode(
+            workspace="ws-guid-123",
+            item_path="item-guid",
+            table_name="dbo/my table#1",
+        )
+
+        host = DEFAULT_ENVIRONMENT.dfs_host
+        assert app._node_to_https_named(file_node) == (
+            f"https://{host}/My%20Workspace%2FWest/Lake%231/Files/raw%20data/file%20%231.csv"
+        )
+        assert app._node_to_abfss_named(table_node) == (
+            f"abfss://My%20Workspace%2FWest@{host}/Lake%231/Tables/dbo/my%20table%231"
+        )
+
+
+@pytest.mark.asyncio
 async def test_copy_to_clipboard_uses_platform_command():
     """macOS path should use pbcopy command."""
     app, _ = _create_app_harness()

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -593,6 +593,31 @@ async def test_named_uri_builders_encode_special_characters():
 
 
 @pytest.mark.asyncio
+async def test_guid_uri_builders_use_node_workspace_id():
+    """GUID URI builders should use workspace from the selected node, not tree state."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("#tree", OneLakeTree)
+        tree._current_workspace_id = ""
+
+        file_node = FileNode(
+            workspace="ws-guid-from-node",
+            path="item-guid/Files/data.csv",
+            size=1,
+        )
+
+        host = DEFAULT_ENVIRONMENT.dfs_host
+        assert app._node_to_https_guid(file_node) == (
+            f"https://{host}/ws-guid-from-node/item-guid/Files/data.csv"
+        )
+        assert app._node_to_abfss_guid(file_node) == (
+            f"abfss://ws-guid-from-node@{host}/item-guid/Files/data.csv"
+        )
+
+
+@pytest.mark.asyncio
 async def test_copy_to_clipboard_uses_platform_command():
     """macOS path should use pbcopy command."""
     app, _ = _create_app_harness()

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,7 +12,9 @@ from textual.widgets import Input
 from onelake_client.environment import DEFAULT_ENVIRONMENT
 from onelake_client.models import Item
 from onelake_tui.app import OneLakeApp
+from onelake_tui.help_screen import HelpScreen
 from onelake_tui.nodes import FileNode, FolderNode, TableNode
+from onelake_tui.status_bar import StatusBar
 from onelake_tui.tree import OneLakeTree
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -93,20 +96,24 @@ async def test_action_search_escape_hides():
         assert search.display is False
 
 
-# ── 3. test_action_help_notifies ─────────────────────────────────────
+# ── 3. test_action_help_opens_fullscreen ─────────────────────────────
 
 
 @pytest.mark.asyncio
-async def test_action_help_notifies():
-    """Mount app. Call action_help(). Verify it triggers a notification without crashing."""
+async def test_action_help_opens_fullscreen():
+    """Mount app. Help action should push HelpScreen and close with Escape."""
     app, _ = _create_app_harness()
 
     async with app.run_test() as pilot:
         await pilot.pause()
 
-        # Should not raise
         app.action_help()
         await pilot.pause()
+        assert isinstance(app.screen, HelpScreen)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, HelpScreen)
 
 
 # ── 4. test_copy_path_no_selection ───────────────────────────────────
@@ -436,3 +443,157 @@ async def test_node_to_abfss_table():
         result = app._node_to_abfss_guid(table_node)
         host = DEFAULT_ENVIRONMENT.dfs_host
         assert result == f"abfss://ws-guid-123@{host}/item-guid/Tables/dbo/my_table"
+
+
+@pytest.mark.asyncio
+async def test_action_toggle_footer_toggles_display():
+    """Status bar display should toggle on each action call."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        status = app.query_one(StatusBar)
+        assert status.display is True
+
+        app.action_toggle_footer()
+        assert status.display is False
+
+        app.action_toggle_footer()
+        assert status.display is True
+
+
+@pytest.mark.asyncio
+async def test_ctrl_f_key_toggles_footer():
+    """Ctrl+f binding exists and footer action toggles visibility."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        status = app.query_one(StatusBar)
+        assert status.display is True
+
+        assert any(binding.key == "ctrl+f" for binding in app.BINDINGS)
+
+        app.action_toggle_footer()
+        assert status.display is False
+
+
+@pytest.mark.asyncio
+async def test_on_key_panel_shortcuts_call_focus_actions():
+    """h/l shortcuts should call focus previous/next actions."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#tree", OneLakeTree).focus()
+        await pilot.pause()
+
+        with (
+            patch.object(app, "action_focus_previous") as focus_prev,
+            patch.object(app, "action_focus_next") as focus_next,
+        ):
+            left_event = SimpleNamespace(key="h", prevent_default=MagicMock())
+            app.on_key(left_event)
+            focus_prev.assert_called_once()
+            left_event.prevent_default.assert_called_once()
+
+            right_event = SimpleNamespace(key="l", prevent_default=MagicMock())
+            app.on_key(right_event)
+            focus_next.assert_called_once()
+            right_event.prevent_default.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_on_key_vim_nav_shortcuts_map_to_simulate_key():
+    """j/k/g/G should map to down/up/home/end on focused nav widgets."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.query_one("#tree", OneLakeTree).focus()
+        await pilot.pause()
+
+        with patch.object(app, "simulate_key") as simulate_key:
+            for key, expected in (("j", "down"), ("k", "up"), ("g", "home"), ("G", "end")):
+                event = SimpleNamespace(key=key, prevent_default=MagicMock())
+                app.on_key(event)
+                simulate_key.assert_called_with(expected)
+                event.prevent_default.assert_called_once()
+                simulate_key.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_on_key_vim_nav_ignored_while_search_focused():
+    """j/k/g/G shortcuts should not fire while typing in search input."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.action_search()
+        await pilot.pause()
+
+        with patch.object(app, "simulate_key") as simulate_key:
+            event = SimpleNamespace(key="j", prevent_default=MagicMock())
+            app.on_key(event)
+            simulate_key.assert_not_called()
+            event.prevent_default.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_uri_builders_return_none_without_client():
+    """Path builders should safely return None when app client is unavailable."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("#tree", OneLakeTree)
+        tree._current_workspace_name = "MyWorkspace"
+        tree._current_workspace_id = "ws-guid-123"
+        tree._current_item = Item(id="item-guid", display_name="MyLakehouse", type="Lakehouse")
+
+        file_node = FileNode(workspace="ws-guid-123", path="item-guid/Files/data.csv", size=1)
+        app.client = None
+
+        assert app._node_to_https_named(file_node) is None
+        assert app._node_to_https_guid(file_node) is None
+        assert app._node_to_abfss_named(file_node) is None
+        assert app._node_to_abfss_guid(file_node) is None
+
+
+@pytest.mark.asyncio
+async def test_copy_to_clipboard_uses_platform_command():
+    """macOS path should use pbcopy command."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        with (
+            patch("onelake_tui.app.platform.system", return_value="Darwin"),
+            patch("onelake_tui.app.subprocess.run") as run,
+            patch.object(app, "notify") as notify,
+        ):
+            app._copy_to_clipboard("abc", "TEST")
+            run.assert_called_once_with(["pbcopy"], input=b"abc", check=True)
+            notify.assert_called_with("Copied TEST: abc", timeout=3)
+
+
+@pytest.mark.asyncio
+async def test_copy_to_clipboard_linux_fallback_chain():
+    """Linux path should try wl-copy, then xclip, then xsel."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        side_effects = [
+            FileNotFoundError("wl-copy missing"),
+            FileNotFoundError("xclip missing"),
+            None,
+        ]
+        with (
+            patch("onelake_tui.app.platform.system", return_value="Linux"),
+            patch("onelake_tui.app.subprocess.run", side_effect=side_effects) as run,
+            patch.object(app, "notify") as notify,
+        ):
+            app._copy_to_clipboard("abc", "TEST")
+            assert run.call_count == 3
+            notify.assert_called_with("Copied TEST: abc", timeout=3)

--- a/TUI/tests/test_copy_menu.py
+++ b/TUI/tests/test_copy_menu.py
@@ -1,0 +1,62 @@
+"""Tests for the copy-format modal menu."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+from onelake_tui.copy_menu import CopyFormatMenu
+
+
+class _CopyMenuHarness(App):
+    """Minimal harness that opens CopyFormatMenu on mount."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.result: str | None | object = "__unset__"
+
+    def compose(self) -> ComposeResult:
+        yield Static("host")
+
+    def on_mount(self) -> None:
+        self.push_screen(CopyFormatMenu(), callback=self._on_result)
+
+    def _on_result(self, value: str | None) -> None:
+        self.result = value
+
+
+@pytest.mark.asyncio
+async def test_copy_menu_numeric_shortcut_selects_format():
+    """Pressing 1 should select HTTPS named format."""
+    app = _CopyMenuHarness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("1")
+        await pilot.pause()
+        assert app.result == "https_named"
+
+
+@pytest.mark.asyncio
+async def test_copy_menu_escape_dismisses_with_none():
+    """Escape should dismiss menu without selecting a format."""
+    app = _CopyMenuHarness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_copy_menu_enter_selects_highlighted_option():
+    """Arrow + Enter should select the highlighted option."""
+    app = _CopyMenuHarness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("down", "enter")
+        await pilot.pause()
+        assert app.result == "https_guid"

--- a/TUI/tests/test_detail_features.py
+++ b/TUI/tests/test_detail_features.py
@@ -163,7 +163,7 @@ class TestPathFormatBuilders:
     HOST = "onelake.dfs.fabric.microsoft.com"
 
     def _make_named_path(self, ws_name, item_name, rel):
-        return f"onelake://{ws_name}/{item_name}/{rel}"
+        return f"{ws_name} / {item_name} / {rel}"
 
     def _make_abfss_path(self, ws_id, host, full_path):
         return f"abfss://{ws_id}@{host}/{full_path}"
@@ -175,17 +175,17 @@ class TestPathFormatBuilders:
         directory = f"{self.ITEM_ID}/Files"
         rel = directory.split("/", 1)[-1]
         path = self._make_named_path(self.WS_NAME, self.ITEM_NAME, rel)
-        assert path == "onelake://MyWorkspace/MyLakehouse/Files"
+        assert path == "MyWorkspace / MyLakehouse / Files"
 
     def test_named_path_for_file(self):
         file_path = f"{self.ITEM_ID}/Files/data.csv"
         rel = file_path.split("/", 1)[-1]
         path = self._make_named_path(self.WS_NAME, self.ITEM_NAME, rel)
-        assert path == "onelake://MyWorkspace/MyLakehouse/Files/data.csv"
+        assert path == "MyWorkspace / MyLakehouse / Files/data.csv"
 
     def test_named_path_for_table(self):
         path = self._make_named_path(self.WS_NAME, self.ITEM_NAME, "Tables/customers")
-        assert path == "onelake://MyWorkspace/MyLakehouse/Tables/customers"
+        assert path == "MyWorkspace / MyLakehouse / Tables/customers"
 
     def test_abfss_path_for_folder(self):
         directory = f"{self.ITEM_ID}/Files"

--- a/TUI/tests/test_detail_preview.py
+++ b/TUI/tests/test_detail_preview.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Markdown, Static, TextArea
 
 from onelake_client.environment import DEFAULT_ENVIRONMENT
+from onelake_client.exceptions import FileTooLargeError
+from onelake_client.models import PathInfo
 from onelake_tui.detail import (
     _MAX_PREVIEW_BYTES,
     DetailPanel,
 )
-from onelake_tui.nodes import FileNode
+from onelake_tui.nodes import FileNode, TableNode
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -250,3 +252,36 @@ async def test_preview_ndjson_formats_lines():
         # Verify a TextArea is mounted with formatted JSON
         textareas = detail.query(TextArea)
         assert len(textareas) > 0, "Expected TextArea to be mounted for NDJSON preview"
+
+
+@pytest.mark.asyncio
+async def test_read_parquet_fallback_skips_oversized_unknown_and_tries_next():
+    """Parquet fallback should keep trying candidates when unknown-size file exceeds max_bytes."""
+    client = _make_mock_client()
+    detail = DetailPanel(client)
+    table = TableNode(workspace="ws", item_path="item-guid", table_name="dbo/table")
+
+    client.dfs.list_paths = AsyncMock(
+        return_value=[
+            PathInfo(name="item-guid/Tables/dbo/table/huge.parquet", isDirectory=False),
+            PathInfo(name="item-guid/Tables/dbo/table/small.parquet", isDirectory=False),
+        ]
+    )
+    client.dfs.read_file = AsyncMock(
+        side_effect=[
+            FileTooLargeError(size=100 * 1024 * 1024, max_bytes=50 * 1024 * 1024),
+            b"parquet-bytes",
+        ]
+    )
+
+    sample = MagicMock(name="sample")
+    row_groups = MagicMock(name="row_groups")
+    row_groups.slice.return_value = sample
+    parquet_file = MagicMock(name="parquet_file")
+    parquet_file.read_row_groups.return_value = row_groups
+
+    with patch("pyarrow.parquet.ParquetFile", return_value=parquet_file):
+        result = await detail._read_parquet_fallback(table)
+
+    assert result is sample
+    assert client.dfs.read_file.await_count == 2

--- a/TUI/tests/test_detail_preview.py
+++ b/TUI/tests/test_detail_preview.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from textual.app import App, ComposeResult
@@ -13,6 +13,7 @@ from onelake_client.environment import DEFAULT_ENVIRONMENT
 from onelake_client.exceptions import FileTooLargeError
 from onelake_client.models import PathInfo
 from onelake_tui.detail import (
+    _MAX_BINARY_BYTES,
     _MAX_PREVIEW_BYTES,
     DetailPanel,
 )
@@ -255,7 +256,7 @@ async def test_preview_ndjson_formats_lines():
 
 
 @pytest.mark.asyncio
-async def test_read_parquet_fallback_skips_oversized_unknown_and_tries_next():
+async def test_parquet_fallback_retries_on_file_too_large_error():
     """Parquet fallback should keep trying candidates when unknown-size file exceeds max_bytes."""
     client = _make_mock_client()
     detail = DetailPanel(client)
@@ -269,7 +270,7 @@ async def test_read_parquet_fallback_skips_oversized_unknown_and_tries_next():
     )
     client.dfs.read_file = AsyncMock(
         side_effect=[
-            FileTooLargeError(size=100 * 1024 * 1024, max_bytes=50 * 1024 * 1024),
+            FileTooLargeError(size=_MAX_BINARY_BYTES * 2, max_bytes=_MAX_BINARY_BYTES),
             b"parquet-bytes",
         ]
     )
@@ -285,3 +286,57 @@ async def test_read_parquet_fallback_skips_oversized_unknown_and_tries_next():
 
     assert result is sample
     assert client.dfs.read_file.await_count == 2
+    client.dfs.read_file.assert_has_awaits(
+        [
+            call(
+                "ws",
+                "item-guid/Tables/dbo/table/huge.parquet",
+                max_bytes=_MAX_BINARY_BYTES,
+            ),
+            call(
+                "ws",
+                "item-guid/Tables/dbo/table/small.parquet",
+                max_bytes=_MAX_BINARY_BYTES,
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_parquet_fallback_prioritizes_known_size_candidates():
+    """Known-size parquet candidates should be attempted before unknown-size ones."""
+    client = _make_mock_client()
+    detail = DetailPanel(client)
+    table = TableNode(workspace="ws", item_path="item-guid", table_name="dbo/table")
+
+    client.dfs.list_paths = AsyncMock(
+        return_value=[
+            PathInfo(name="item-guid/Tables/dbo/table/unknown.parquet", isDirectory=False),
+            PathInfo(
+                name="item-guid/Tables/dbo/table/known.parquet",
+                isDirectory=False,
+                contentLength=1024,
+            ),
+        ]
+    )
+    client.dfs.read_file = AsyncMock(return_value=b"parquet-bytes")
+
+    sample = MagicMock(name="sample")
+    row_groups = MagicMock(name="row_groups")
+    row_groups.slice.return_value = sample
+    parquet_file = MagicMock(name="parquet_file")
+    parquet_file.read_row_groups.return_value = row_groups
+
+    with patch("pyarrow.parquet.ParquetFile", return_value=parquet_file):
+        result = await detail._read_parquet_fallback(table)
+
+    assert result is sample
+    client.dfs.read_file.assert_has_awaits(
+        [
+            call(
+                "ws",
+                "item-guid/Tables/dbo/table/known.parquet",
+                max_bytes=_MAX_BINARY_BYTES,
+            ),
+        ]
+    )

--- a/TUI/tests/test_robustness.py
+++ b/TUI/tests/test_robustness.py
@@ -138,7 +138,7 @@ async def test_status_bar_very_long_path():
         status = app.query_one("#status", StatusBar)
 
         # Set a 200-char path
-        long_path = "onelake://" + "a" * 200
+        long_path = "a" * 200
         status.path = long_path
 
         output = status.render()
@@ -164,7 +164,7 @@ async def test_status_bar_special_chars_in_path():
         status = app.query_one("#status", StatusBar)
 
         # Set path with special chars that could be Rich markup
-        special_path = "onelake://ws/[special]/file [copy].txt"
+        special_path = "ws / [special] / file [copy].txt"
         status.path = special_path
 
         # render() should not crash
@@ -183,7 +183,7 @@ async def test_status_bar_render_with_various_fields():
         status = app.query_one("#status", StatusBar)
 
         # Test with various field combinations
-        status.path = "onelake://test-workspace/item-name"
+        status.path = "test-workspace / item-name"
         status.item_count = 42
         status.auth_method = "msal"
         status.identity = "user@contoso.com"
@@ -191,7 +191,7 @@ async def test_status_bar_render_with_various_fields():
 
         output = status.render()
 
-        assert "onelake://test-workspace/item-name" in output
+        assert "test-workspace / item-name" in output
         assert "42 items" in output
         assert "msal" in output
         assert "user@contoso.com" in output

--- a/TUI/tests/test_widget_loading.py
+++ b/TUI/tests/test_widget_loading.py
@@ -90,7 +90,7 @@ async def test_status_bar_update_path():
         await pilot.pause()
         status = app.query_one("#status", StatusBar)
 
-        new_path = "onelake://MyWS/MyLH"
+        new_path = "MyWS / MyLH"
         status.update_path(new_path)
 
         # Verify the path property was updated
@@ -109,7 +109,7 @@ async def test_status_bar_long_path_truncated():
         status = app.query_one("#status", StatusBar)
 
         # Create a long path (>80 chars)
-        long_path = "onelake://" + "a" * 200
+        long_path = "a" * 200
         status.path = long_path
 
         output = status.render()
@@ -304,7 +304,7 @@ async def test_status_bar_item_count_display():
         await pilot.pause()
         status = app.query_one("#status", StatusBar)
 
-        status.update_path("onelake://ws/item", item_count=42)
+        status.update_path("ws / item", item_count=42)
 
         output = status.render()
 

--- a/docs/decisions/004-delta-tabbed-detail-and-copy-shortcuts.md
+++ b/docs/decisions/004-delta-tabbed-detail-and-copy-shortcuts.md
@@ -8,7 +8,7 @@ tags: [tui, delta, clipboard, ux]
 
 ## Context
 
-The Delta table detail panel showed all metadata in a flat scrollable view — schema, version, file count, size. Users needed richer insight: data preview, transaction history, and Change Data Feed status. Separately, the single `y` shortcut only copied the named `onelake://` path, but ABFSS and HTTPS URL formats are needed for Spark notebooks and REST API calls respectively.
+The Delta table detail panel showed all metadata in a flat scrollable view — schema, version, file count, size. Users needed richer insight: data preview, transaction history, and Change Data Feed status. For copy operations, users needed fast access to both named and GUID variants of HTTPS and ABFSS URIs.
 
 ## Decision
 
@@ -25,19 +25,20 @@ Replace the flat table detail with four tabs:
 
 Data preview is lazy to avoid expensive reads on large tables. The user clicks "Load Data Preview" to trigger it.
 
-### Three copy formats
+### Copy menu (`y`) with four URI targets
 
-| Key | Format | Example |
-|-----|--------|---------|
-| `y` | Named `onelake://` | `onelake://MyWorkspace/MyLakehouse/Tables/customers` |
-| `Y` (Shift) | ABFSS with GUIDs | `abfss://{wsGUID}@onelake.dfs.fabric.microsoft.com/{itemGUID}/Tables/customers` |
-| `Ctrl+Y` | HTTPS DFS URL | `https://onelake.dfs.fabric.microsoft.com/{wsGUID}/{itemGUID}/Tables/customers` |
+| Trigger | Format | Example |
+|---------|--------|---------|
+| `y` → option 1 | HTTPS with names | `https://onelake.dfs.fabric.microsoft.com/MyWorkspace/MyLakehouse/Tables/customers` |
+| `y` → option 2 | HTTPS with GUIDs | `https://onelake.dfs.fabric.microsoft.com/{wsGUID}/{itemGUID}/Tables/customers` |
+| `y` → option 3 | ABFSS with names | `abfss://MyWorkspace@onelake.dfs.fabric.microsoft.com/MyLakehouse/Tables/customers` |
+| `y` → option 4 | ABFSS with GUIDs | `abfss://{wsGUID}@onelake.dfs.fabric.microsoft.com/{itemGUID}/Tables/customers` |
 
-All use the existing `pbcopy` mechanism (macOS; graceful fallback to notification display).
+Clipboard uses platform-native command paths with graceful fallback when no clipboard backend is available.
 
 ## Consequences
 
 - `fastavro` added as dependency for Avro file preview (same session).
 - Tabbed UI requires Textual ≥ 0.27 (we depend on ≥ 1.0, so fine).
-- Transaction log reads up to 20 JSON files from `_delta_log/` — could be slow on high-version tables. Capped to last 20 commits.
+- Transaction log reads up to 20 JSON files from `_delta_log/` using bounded parallelism for lower latency.
 - CDF tab uses `deltalake` `load_cdf()` which may not be available in all delta-rs versions. Fails gracefully.


### PR DESCRIPTION
## Summary

Keyboard/UX overhaul plus follow-up remediation from the project audit.

### UX and navigation
- `y` now opens a copy menu with 4 URI targets (HTTPS/ABFSS × named/GUID)
- Vim-friendly navigation: `j/k/g/G` and panel switching `h/l` (Tab/Shift+Tab retained)
- `?` now opens a full-screen help overlay
- `Ctrl+f` toggles footer visibility

### Reliability and performance fixes
- Cross-platform clipboard command fallback (macOS/Windows/Linux) with graceful fallback display
- Defensive client-null guards in URI builders
- Delta history loading now uses bounded parallel reads
- Parquet fallback preview now enforces memory-safe size limits

### Release and documentation hardening
- Publish workflow now runs lint + unit tests before build/publish
- Docs/splash/decision record/changelog synchronized with current keymap and URI behavior
- SECURITY supported-version table updated
- HTTP user-agent version is now dynamically resolved from package metadata

### Testing
- Added interaction coverage for help/footer/keybindings/clipboard behavior
- Added dedicated copy-menu tests
- Validation: `312 passed` (unit test set, integration excluded) + `ruff check` clean

### Related
- Integration-testing strategy tracking issue: #8
