### PR TITLE
fix(copy): percent-encode GUID URI paths for copied links

### DIFF
--- a/TUI/src/onelake_tui/app.py
+++ b/TUI/src/onelake_tui/app.py
@@ -425,11 +425,14 @@ class OneLakeApp(App):
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            return f"https://{host}/{data.workspace}/{data.directory}"
+            return f"https://{host}/{data.workspace}/{self._encode_path(data.directory)}"
         elif isinstance(data, FileNode):
-            return f"https://{host}/{data.workspace}/{data.path}"
+            return f"https://{host}/{data.workspace}/{self._encode_path(data.path)}"
         elif isinstance(data, TableNode):
-            return f"https://{host}/{data.workspace}/{data.item_path}/Tables/{data.table_name}"
+            return (
+                f"https://{host}/{data.workspace}/{data.item_path}/Tables/"
+                f"{self._encode_path(data.table_name)}"
+            )
         return None
 
     def _node_to_abfss_named(self, data: object) -> str | None:
@@ -463,11 +466,14 @@ class OneLakeApp(App):
         host = self.client.env.dfs_host
 
         if isinstance(data, FolderNode):
-            return f"abfss://{data.workspace}@{host}/{data.directory}"
+            return f"abfss://{data.workspace}@{host}/{self._encode_path(data.directory)}"
         elif isinstance(data, FileNode):
-            return f"abfss://{data.workspace}@{host}/{data.path}"
+            return f"abfss://{data.workspace}@{host}/{self._encode_path(data.path)}"
         elif isinstance(data, TableNode):
-            return f"abfss://{data.workspace}@{host}/{data.item_path}/Tables/{data.table_name}"
+            return (
+                f"abfss://{data.workspace}@{host}/{data.item_path}/Tables/"
+                f"{self._encode_path(data.table_name)}"
+            )
         return None
 
     def action_refresh(self) -> None:

--- a/TUI/tests/test_app_interactions.py
+++ b/TUI/tests/test_app_interactions.py
@@ -618,6 +618,34 @@ async def test_guid_uri_builders_use_node_workspace_id():
 
 
 @pytest.mark.asyncio
+async def test_guid_uri_builders_encode_special_characters():
+    """GUID URI builders should percent-encode unsafe chars in data path segments."""
+    app, _ = _create_app_harness()
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        file_node = FileNode(
+            workspace="ws-guid-123",
+            path="item-guid/Files/raw data/file #1.csv",
+            size=1,
+        )
+        table_node = TableNode(
+            workspace="ws-guid-123",
+            item_path="item-guid",
+            table_name="dbo/my table#1",
+        )
+
+        host = DEFAULT_ENVIRONMENT.dfs_host
+        assert app._node_to_https_guid(file_node) == (
+            f"https://{host}/ws-guid-123/item-guid/Files/raw%20data/file%20%231.csv"
+        )
+        assert app._node_to_abfss_guid(table_node) == (
+            f"abfss://ws-guid-123@{host}/item-guid/Tables/dbo/my%20table%231"
+        )
+
+
+@pytest.mark.asyncio
 async def test_copy_to_clipboard_uses_platform_command():
     """macOS path should use pbcopy command."""
     app, _ = _create_app_harness()


### PR DESCRIPTION
## Why
Copying GUID-based URIs from the `y` copy menu produced raw path/table segments.
When those segments contained spaces or symbols (for example `#`), the generated URI was not properly encoded.

## What changed
1. Updated GUID URI builders in `TUI/src/onelake_tui/app.py`:
   - `_node_to_https_guid`
   - `_node_to_abfss_guid`
2. Applied `_encode_path(...)` to GUID-based path segments:
   - `FolderNode.directory`
   - `FileNode.path`
   - `TableNode.table_name`
3. Preserved existing behavior for host/workspace GUID/item GUID and slash separators.

## Before vs after
Before:
- `https://<host>/ws-guid/item-guid/Files/raw data/file #1.csv`
- `abfss://ws-guid@<host>/item-guid/Tables/dbo/my table#1`

After:
- `https://<host>/ws-guid/item-guid/Files/raw%20data/file%20%231.csv`
- `abfss://ws-guid@<host>/item-guid/Tables/dbo/my%20table%231`

## Test coverage
Added `test_guid_uri_builders_encode_special_characters` in:
- `TUI/tests/test_app_interactions.py`

This regression test verifies GUID HTTPS/ABFSS URI output is percent-encoded for spaces/symbols.

## Validation
- `cd TUI && uv run ruff check src/ tests/`
- `cd TUI && uv run pytest` (317 passed, 6 skipped)

## Scope / risk
- No changes to named URI builders.
- No changes to URI host selection or GUID source fields.
- Change is isolated to URI string construction for GUID copy formats.