### PR TITLE
docs: roadmap items with linked GitHub issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,13 @@ OneLakeTools/
 | File preview (MD/JSON/CSV/Parquet/Avro) | ✅ Done |
 | Delta table detail (schema/data/history/CDF) | ✅ Done |
 | Workspace search/filter | ✅ Done |
-| OneLake CLI | 🔲 Planned (`onelake ls`, `onelake cat`, `onelake cp`) |
-| Download/upload | 🔲 Planned |
-| VSCode extension | 💭 Future |
+| [OneLake CLI](https://github.com/lmoloney/OneLakeTools/issues/11) | 🔲 Planned (`onelake ls`, `onelake cat`, `onelake cp`) |
+| [Download/upload](https://github.com/lmoloney/OneLakeTools/issues/12) | 🔲 Planned |
+| [Shortcuts discoverability/manageability](https://github.com/lmoloney/OneLakeTools/issues/13) | 🔲 Planned |
+| [ADLS direct connections](https://github.com/lmoloney/OneLakeTools/issues/14) | 🔲 Planned |
+| [OneLake security policy management](https://github.com/lmoloney/OneLakeTools/issues/15) | 🔲 Planned |
+| [Bulk operations](https://github.com/lmoloney/OneLakeTools/issues/16) | 🔲 Planned |
+| [Copying data + soft-deleted data handling](https://github.com/lmoloney/OneLakeTools/issues/17) | 🔲 Planned |
 
 ## License
 

--- a/TUI/README.md
+++ b/TUI/README.md
@@ -36,6 +36,24 @@ Built with [Textual](https://textual.textualize.io/) and an async Python client 
 - **Toggleable footer** — `Ctrl+F` hides/shows the status bar
 - **Zero config** — uses `az login`, no service keys or config files required
 
+## Roadmap (linked issues)
+
+Roadmap source of truth: [`../README.md#roadmap`](../README.md#roadmap)
+
+| Area | Status |
+|------|--------|
+| OneLake TUI (Unofficial) | ✅ Working (browse, preview, inspect, copy path) |
+| File preview (MD/JSON/CSV/Parquet/Avro) | ✅ Done |
+| Delta table detail (schema/data/history/CDF) | ✅ Done |
+| Workspace search/filter | ✅ Done |
+| [OneLake CLI](https://github.com/lmoloney/OneLakeTools/issues/11) | 🔲 Planned (`onelake ls`, `onelake cat`, `onelake cp`) |
+| [Download/upload](https://github.com/lmoloney/OneLakeTools/issues/12) | 🔲 Planned |
+| [Shortcuts discoverability/manageability](https://github.com/lmoloney/OneLakeTools/issues/13) | 🔲 Planned |
+| [ADLS direct connections](https://github.com/lmoloney/OneLakeTools/issues/14) | 🔲 Planned |
+| [OneLake security policy management](https://github.com/lmoloney/OneLakeTools/issues/15) | 🔲 Planned |
+| [Bulk operations](https://github.com/lmoloney/OneLakeTools/issues/16) | 🔲 Planned |
+| [Copying data + soft-deleted data handling](https://github.com/lmoloney/OneLakeTools/issues/17) | 🔲 Planned |
+
 ## Installation
 
 **Prerequisites:** Python 3.11+, Azure CLI (`az login`)


### PR DESCRIPTION
## Summary
- update root roadmap table in README.md to use issue-linked planned items
- add matching roadmap section to TUI/README.md (aligned with root roadmap)
- remove VSCode extension roadmap row for now

## Added roadmap issue links
- [#11](https://github.com/lmoloney/OneLakeTools/issues/11) OneLake CLI initial command set
- [#12](https://github.com/lmoloney/OneLakeTools/issues/12) Download/upload workflows
- [#13](https://github.com/lmoloney/OneLakeTools/issues/13) Shortcuts discoverability/manageability
- [#14](https://github.com/lmoloney/OneLakeTools/issues/14) ADLS direct connections
- [#15](https://github.com/lmoloney/OneLakeTools/issues/15) OneLake security policy management
- [#16](https://github.com/lmoloney/OneLakeTools/issues/16) Bulk operations
- [#17](https://github.com/lmoloney/OneLakeTools/issues/17) Copying data + soft-deleted data handling

## Notes
- status language remains consistent with existing roadmap rows (✅ Done, 🔲 Planned)
- TUI/README.md includes a source-of-truth pointer to README.md#roadmap to reduce drift