### PR TITLE
fix: handle timestamp[ns] cast failure in data preview

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    enabled: false
+    ignore_drafts: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
 reviews:
   auto_review:
     enabled: false
-    ignore_drafts: true
+    drafts: false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -136,9 +136,20 @@ TUI/src/
 3. Add the `--env` choice to the CLI arg parser in `onelake_tui/app.py`.
 4. Token scopes do NOT change per ring — only hostnames differ (see [ADR-003](../docs/decisions/003-shared-token-scopes.md)).
 
+## Changelog
+
+Update `CHANGELOG.md` under `[Unreleased]` for every user-facing change. Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with `Added`, `Changed`, `Fixed`, `Removed` sections. Reference the GitHub issue number where applicable (e.g. `(#19)`).
+
 ## Decision Records
 
 Architecture decisions live in [`docs/decisions/`](../docs/decisions/). Lightweight ADR format with YAML front matter (id, title, status, date, tags). When making architectural decisions, create a new record numbered sequentially.
+
+## Documentation
+
+When a change affects user-facing behavior, CLI flags, keybindings, or supported file formats, update the relevant docs:
+- `README.md` for usage, installation, or feature descriptions
+- `docs/runbooks/` for operational procedures
+- `.github/copilot-instructions.md` if the change affects project structure, conventions, or module responsibilities
 
 ## Debugging
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -97,6 +97,7 @@ TUI/src/
 - Only API hostnames change per ring. See [ADR-003](../docs/decisions/003-shared-token-scopes.md)
 - MSIT Fabric REST: `msitapi.fabric.microsoft.com` (NOT `api.msit.fabric.microsoft.com`)
 - Delta abfss:// URIs must use the correct DFS host per ring (passed from `FabricEnvironment.dfs_host`)
+- `coerce_timestamps()` from `onelake_client.tables` must be applied after reading pyarrow Tables from Delta/Parquet to handle `timestamp[ns]` → `timestamp[us]` schema mismatches. If `ds.head()` raises `ArrowInvalid`, fall back to reading fragments with their physical schema first.
 
 ### Rich Markup Safety
 - All dynamic values in `Static()` widgets MUST be wrapped with `rich.markup.escape()`

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -29,3 +29,4 @@ When performing a code review, apply these checks in addition to standard correc
 - `deltalake` >= 1.5 returns `arro3.core.Table` from `get_add_actions(flatten=True)` — use `.column(name).to_pylist()`, not `.to_pydict()`.
 - `dt.schema()` returns a `Schema` object — iterate via `.fields`, not directly.
 - `dt.file_uris()` replaces the old `dt.files()`.
+- Use `pa.lib.ArrowInvalid` (not `pa.ArrowInvalid`) for exception handling — both refer to the same object, but `pa.lib` is where pyarrow defines its exceptions and is consistent with what pyarrow raises at runtime.

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,31 @@
+---
+applyTo: "**"
+---
+
+# Code Review Instructions
+
+When performing a code review, apply these checks in addition to standard correctness and security review.
+
+## Changelog
+
+- If the PR contains user-facing changes (bug fixes, new features, changed behavior) and `CHANGELOG.md` was not modified, flag this and request an entry under `[Unreleased]`.
+- Changelog entries should follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with `Added`, `Changed`, `Fixed`, or `Removed` sections.
+- Changelog entries should reference the GitHub issue number where applicable (e.g. `(#19)`).
+- Do not flag changelog for PRs that only change CI configuration, tests, or internal refactors with no user-visible impact.
+
+## Documentation
+
+- If the PR changes CLI flags, keybindings, supported file formats, or public API surface, check that `README.md` was updated accordingly. Flag if not.
+- If the PR changes project structure, module responsibilities, or key conventions, check that `.github/copilot-instructions.md` was updated. Flag if not.
+- Do not flag documentation for PRs that only change CI configuration, tests, or internal refactors with no user-visible impact.
+
+## Rich markup safety
+
+- Any dynamic string rendered in a Textual `Static()` widget must be wrapped with `rich.markup.escape()`. Flag unescaped dynamic values.
+- Error notifications must use `markup=False`. Flag if not.
+
+## Delta / pyarrow conventions
+
+- `deltalake` >= 1.5 returns `arro3.core.Table` from `get_add_actions(flatten=True)` — use `.column(name).to_pylist()`, not `.to_pydict()`.
+- `dt.schema()` returns a `Schema` object — iterate via `.fields`, not directly.
+- `dt.file_uris()` replaces the old `dt.files()`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,29 @@ on:
     branches: [main]
 
 jobs:
+  changelog:
+    name: Changelog updated
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'chore') && !contains(github.event.pull_request.labels.*.name, 'documentation')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check CHANGELOG.md was modified
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if git diff --name-only "$BASE" "$HEAD" | grep -q '^CHANGELOG.md$'; then
+            echo "✅ CHANGELOG.md updated"
+          else
+            echo "::error::CHANGELOG.md was not updated. Please add an entry under [Unreleased]."
+            echo ""
+            echo "If this PR is docs-only or chore-only, add the 'chore' label to skip this check."
+            exit 1
+          fi
+
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           else
             echo "::error::CHANGELOG.md was not updated. Please add an entry under [Unreleased]."
             echo ""
-            echo "If this PR is docs-only or chore-only, add the 'chore' label to skip this check."
+            echo "If this PR is docs-only or chore-only, add the 'documentation' or 'chore' label to skip this check."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           BASE=${{ github.event.pull_request.base.sha }}
           HEAD=${{ github.event.pull_request.head.sha }}
-          if git diff --name-only "$BASE" "$HEAD" | grep -q '^CHANGELOG.md$'; then
+          if git diff --name-only "$BASE"..."$HEAD" | grep -q '^CHANGELOG.md$'; then
             echo "✅ CHANGELOG.md updated"
           else
             echo "::error::CHANGELOG.md was not updated. Please add an entry under [Unreleased]."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `coerce_timestamps` public helper in `onelake_client.tables` for safely downcasting `timestamp[ns]` columns to `timestamp[us]`
+- CI job that enforces `CHANGELOG.md` updates on user-facing PRs (skip with `chore` or `documentation` label)
+- Code-review instructions (`.github/instructions/code-review.instructions.md`) covering changelog, docs, Rich markup, and pyarrow conventions
+
 ### Fixed
 
-- Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]`, with out-of-range values rendered as null (#19)
+- Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]`, with out-of-range values replaced by null (#19)
 
 ## [0.3.0] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]`, with out-of-range values rendered as null (#19)
+
 ## [0.3.0] - 2026-04-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]`, with out-of-range values replaced by null (#19)
+- Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]` with sub-microsecond precision truncated; timestamps outside year 0001–9999 are defensively nullified (#19)
 
 ## [0.3.0] - 2026-04-20
 

--- a/TUI/src/onelake_client/tables/__init__.py
+++ b/TUI/src/onelake_client/tables/__init__.py
@@ -1,4 +1,4 @@
-from onelake_client.tables.delta import DeltaTableReader
+from onelake_client.tables.delta import DeltaTableReader, coerce_timestamps
 from onelake_client.tables.iceberg import IcebergTableReader
 
-__all__ = ["DeltaTableReader", "IcebergTableReader"]
+__all__ = ["DeltaTableReader", "IcebergTableReader", "coerce_timestamps"]

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -51,11 +51,13 @@ def _schema_to_columns(schema) -> list[Column]:
 def _coerce_timestamps(table):
     """Downcast timestamp[ns] columns to timestamp[us] to avoid Arrow cast errors.
 
-    Parquet files written with nanosecond-precision timestamps (or corrupt
-    sentinel values) cause ``ArrowInvalid: Casting from timestamp[ns] to
-    timestamp[us, tz=UTC] would lose data`` when pyarrow reads them.
-    We cast with ``safe=False`` so out-of-range values become null rather
-    than crashing the preview.
+    Parquet files written with nanosecond-precision timestamps can trigger
+    ``ArrowInvalid: Casting from timestamp[ns] to timestamp[us, tz=UTC]
+    would lose data`` when pyarrow reads them.
+
+    We cast with ``safe=False`` so the lossy ns→us downcast is allowed
+    instead of raising. This truncates sub-microsecond precision; it does
+    not implicitly convert invalid or out-of-range values to null.
     """
     import pyarrow as pa
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -363,7 +363,9 @@ class DeltaTableReader:
             ds = dt.to_pyarrow_dataset()
             try:
                 table = ds.head(limit)
-            except pa.lib.ArrowInvalid:
+            except pa.lib.ArrowInvalid as exc:
+                if "timestamp" not in str(exc).lower():
+                    raise
                 # Delta schema says timestamp[us] but parquet has timestamp[ns].
                 # Re-read fragments with their physical (parquet) schema to
                 # bypass the safe cast, then let coerce_timestamps handle it.

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -63,7 +63,7 @@ def _nullify_out_of_range(col, target_type):
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    # Year 0001-01-01T00:00:00 and year 9999-12-31T23:59:59 in µs from epoch.
+    # Year 0001-01-01T00:00:00 and year 9999-12-31T23:59:59.999999 in µs from epoch.
     _MIN_US = -62_135_596_800_000_000
     _MAX_US = 253_402_300_799_999_999
 
@@ -89,7 +89,11 @@ def coerce_timestamps(table: pa.Table) -> pa.Table:
 
     We cast with ``safe=False`` so the lossy ns→us downcast is allowed
     instead of raising.  For representable values this truncates
-    sub-microsecond precision; out-of-range values are replaced with null.
+    sub-microsecond precision; timestamps outside year 0001–9999 are
+    defensively nullified via :func:`_nullify_out_of_range`.
+
+    If *table* is not a :class:`pyarrow.Table` (e.g. a test mock),
+    it is returned unchanged.
     """
     import pyarrow as pa
 
@@ -118,10 +122,6 @@ def coerce_timestamps(table: pa.Table) -> pa.Table:
             new_col,
         )
     return table
-
-
-# Deprecated backward-compatible alias; use ``coerce_timestamps`` instead.
-_coerce_timestamps = coerce_timestamps
 
 
 # ── Subprocess workers (top-level for pickling) ────────────────────────
@@ -364,21 +364,24 @@ class DeltaTableReader:
             try:
                 table = ds.head(limit)
             except pa.lib.ArrowInvalid as exc:
-                if "timestamp" not in str(exc).lower():
+                exc_msg = str(exc).lower()
+                if "timestamp[ns]" not in exc_msg or "would lose data" not in exc_msg:
                     raise
                 # Delta schema says timestamp[us] but parquet has timestamp[ns].
                 # Re-read fragments with their physical (parquet) schema to
                 # bypass the safe cast, then let coerce_timestamps handle it.
+                _MAX_FALLBACK_FRAGMENTS = 10
                 batches: list[pa.RecordBatch] = []
                 remaining = limit
-                for frag in ds.get_fragments():
-                    if remaining <= 0:
+                for frag_idx, frag in enumerate(ds.get_fragments()):
+                    if remaining <= 0 or frag_idx >= _MAX_FALLBACK_FRAGMENTS:
                         break
                     for batch in frag.to_batches(schema=frag.physical_schema):
                         if remaining <= 0:
                             break
-                        batches.append(batch.slice(0, remaining))
-                        remaining -= batch.num_rows
+                        sliced = batch.slice(0, remaining)
+                        batches.append(sliced)
+                        remaining -= sliced.num_rows
                 table = pa.Table.from_batches(batches) if batches else pa.table({})
             return coerce_timestamps(table)
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -318,6 +318,8 @@ class DeltaTableReader:
         def _head():
             ds = dt.to_pyarrow_dataset()
             table = ds.head(limit)
+            if not hasattr(table, "num_columns") or not hasattr(table, "schema"):
+                return table
             return _coerce_timestamps(table)
 
         return await asyncio.to_thread(_head)

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -84,7 +84,7 @@ def coerce_timestamps(table):
     return table
 
 
-# Backward-compatible alias kept for existing imports.
+# Deprecated backward-compatible alias; use ``coerce_timestamps`` instead.
 _coerce_timestamps = coerce_timestamps
 
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -48,6 +48,40 @@ def _schema_to_columns(schema) -> list[Column]:
     return columns
 
 
+def _coerce_timestamps(table):
+    """Downcast timestamp[ns] columns to timestamp[us] to avoid Arrow cast errors.
+
+    Parquet files written with nanosecond-precision timestamps (or corrupt
+    sentinel values) cause ``ArrowInvalid: Casting from timestamp[ns] to
+    timestamp[us, tz=UTC] would lose data`` when pyarrow reads them.
+    We cast with ``safe=False`` so out-of-range values become null rather
+    than crashing the preview.
+    """
+    import pyarrow as pa
+
+    new_columns = []
+    needs_cast = False
+    for i in range(table.num_columns):
+        field = table.schema.field(i)
+        if pa.types.is_timestamp(field.type) and field.type.unit == "ns":
+            target_type = pa.timestamp("us", tz=field.type.tz)
+            new_columns.append((i, table.column(i).cast(target_type, safe=False)))
+            needs_cast = True
+
+    if not needs_cast:
+        return table
+
+    for col_idx, new_col in new_columns:
+        field = table.schema.field(col_idx)
+        target_type = pa.timestamp("us", tz=field.type.tz)
+        table = table.set_column(
+            col_idx,
+            field.with_type(target_type),
+            new_col,
+        )
+    return table
+
+
 # ── Subprocess workers (top-level for pickling) ────────────────────────
 
 
@@ -283,7 +317,8 @@ class DeltaTableReader:
 
         def _head():
             ds = dt.to_pyarrow_dataset()
-            return ds.head(limit)
+            table = ds.head(limit)
+            return _coerce_timestamps(table)
 
         return await asyncio.to_thread(_head)
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -48,7 +48,7 @@ def _schema_to_columns(schema) -> list[Column]:
     return columns
 
 
-def _coerce_timestamps(table):
+def coerce_timestamps(table):
     """Downcast timestamp[ns] columns to timestamp[us] to avoid Arrow cast errors.
 
     Parquet files written with nanosecond-precision timestamps can trigger
@@ -82,6 +82,9 @@ def _coerce_timestamps(table):
             new_col,
         )
     return table
+
+
+_coerce_timestamps = coerce_timestamps
 
 
 # ── Subprocess workers (top-level for pickling) ────────────────────────
@@ -322,7 +325,7 @@ class DeltaTableReader:
             table = ds.head(limit)
             if not hasattr(table, "num_columns") or not hasattr(table, "schema"):
                 return table
-            return _coerce_timestamps(table)
+            return coerce_timestamps(table)
 
         return await asyncio.to_thread(_head)
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -382,7 +382,11 @@ class DeltaTableReader:
                         sliced = batch.slice(0, remaining)
                         batches.append(sliced)
                         remaining -= sliced.num_rows
-                table = pa.Table.from_batches(batches) if batches else pa.table({})
+                table = (
+                    pa.Table.from_batches(batches)
+                    if batches
+                    else pa.table({f.name: pa.array([], type=f.type) for f in ds.schema})
+                )
             return coerce_timestamps(table)
 
         return await asyncio.to_thread(_head)

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -56,8 +56,8 @@ def coerce_timestamps(table):
     would lose data`` when pyarrow reads them.
 
     We cast with ``safe=False`` so the lossy ns→us downcast is allowed
-    instead of raising. This truncates sub-microsecond precision; it does
-    not implicitly convert invalid or out-of-range values to null.
+    instead of raising. For representable values this truncates
+    sub-microsecond precision.
     """
     import pyarrow as pa
 
@@ -84,6 +84,7 @@ def coerce_timestamps(table):
     return table
 
 
+# Backward-compatible alias kept for existing imports.
 _coerce_timestamps = coerce_timestamps
 
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -358,8 +358,27 @@ class DeltaTableReader:
         dt = await asyncio.to_thread(self._load_table_sync, uri)
 
         def _head():
+            import pyarrow as pa
+
             ds = dt.to_pyarrow_dataset()
-            return coerce_timestamps(ds.head(limit))
+            try:
+                table = ds.head(limit)
+            except pa.lib.ArrowInvalid:
+                # Delta schema says timestamp[us] but parquet has timestamp[ns].
+                # Re-read fragments with their physical (parquet) schema to
+                # bypass the safe cast, then let coerce_timestamps handle it.
+                batches: list[pa.RecordBatch] = []
+                remaining = limit
+                for frag in ds.get_fragments():
+                    if remaining <= 0:
+                        break
+                    for batch in frag.to_batches(schema=frag.physical_schema):
+                        if remaining <= 0:
+                            break
+                        batches.append(batch.slice(0, remaining))
+                        remaining -= batch.num_rows
+                table = pa.Table.from_batches(batches) if batches else pa.table({})
+            return coerce_timestamps(table)
 
         return await asyncio.to_thread(_head)
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -50,6 +50,36 @@ def _schema_to_columns(schema) -> list[Column]:
     return columns
 
 
+def _nullify_out_of_range(col, target_type):
+    """Replace timestamps outside year 0001–9999 with null.
+
+    After a ``safe=False`` cast, corrupt sentinel values may map to
+    dates far outside any reasonable range.  This helper nullifies
+    them so the preview shows ``null`` instead of garbage.
+
+    Bounds are expressed as microseconds-from-epoch and scaled to
+    the target unit so the same logic works for ``us``, ``ms``, and ``s``.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    # Year 0001-01-01T00:00:00 and year 9999-12-31T23:59:59 in µs from epoch.
+    _MIN_US = -62_135_596_800_000_000
+    _MAX_US = 253_402_300_799_999_999
+
+    _SCALE = {"us": 1, "ms": 1_000, "s": 1_000_000}
+    scale = _SCALE.get(target_type.unit)
+    if scale is None:
+        return col
+
+    lo = _MIN_US // scale
+    hi = _MAX_US // scale
+
+    int_view = col.cast(pa.int64())
+    valid = pc.and_(pc.greater_equal(int_view, lo), pc.less_equal(int_view, hi))
+    return pc.if_else(valid, col, pa.scalar(None, type=target_type))
+
+
 def coerce_timestamps(table: pa.Table) -> pa.Table:
     """Downcast timestamp[ns] columns to timestamp[us] to avoid Arrow cast errors.
 
@@ -58,10 +88,13 @@ def coerce_timestamps(table: pa.Table) -> pa.Table:
     would lose data`` when pyarrow reads them.
 
     We cast with ``safe=False`` so the lossy ns→us downcast is allowed
-    instead of raising. For representable values this truncates
-    sub-microsecond precision.
+    instead of raising.  For representable values this truncates
+    sub-microsecond precision; out-of-range values are replaced with null.
     """
     import pyarrow as pa
+
+    if not isinstance(table, pa.Table):
+        return table
 
     new_columns = []
     needs_cast = False
@@ -69,7 +102,8 @@ def coerce_timestamps(table: pa.Table) -> pa.Table:
         field = table.schema.field(i)
         if pa.types.is_timestamp(field.type) and field.type.unit == "ns":
             target_type = pa.timestamp("us", tz=field.type.tz)
-            new_columns.append((i, table.column(i).cast(target_type, safe=False)))
+            cast_col = table.column(i).cast(target_type, safe=False)
+            new_columns.append((i, _nullify_out_of_range(cast_col, target_type)))
             needs_cast = True
 
     if not needs_cast:
@@ -325,10 +359,7 @@ class DeltaTableReader:
 
         def _head():
             ds = dt.to_pyarrow_dataset()
-            table = ds.head(limit)
-            if not hasattr(table, "num_columns") or not hasattr(table, "schema"):
-                return table
-            return coerce_timestamps(table)
+            return coerce_timestamps(ds.head(limit))
 
         return await asyncio.to_thread(_head)
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -9,6 +9,8 @@ from deltalake.exceptions import DeltaError
 from onelake_client.models.table import Column, DeltaTableInfo
 
 if TYPE_CHECKING:
+    import pyarrow as pa
+
     from onelake_client.auth import OneLakeAuth
 
 logger = logging.getLogger("onelake_client.tables.delta")
@@ -48,7 +50,7 @@ def _schema_to_columns(schema) -> list[Column]:
     return columns
 
 
-def coerce_timestamps(table):
+def coerce_timestamps(table: pa.Table) -> pa.Table:
     """Downcast timestamp[ns] columns to timestamp[us] to avoid Arrow cast errors.
 
     Parquet files written with nanosecond-precision timestamps can trigger

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -29,7 +29,7 @@ from textual.widgets import (
 
 from onelake_client import OneLakeClient
 from onelake_client.exceptions import FileTooLargeError
-from onelake_client.tables.delta import _coerce_timestamps
+from onelake_client.tables import coerce_timestamps
 from onelake_tui.nodes import FileNode, FolderNode, TableNode
 from onelake_tui.sprite import OneLakeSprite, get_welcome
 
@@ -602,7 +602,7 @@ class DetailPanel(VerticalScroll):
 
             pf = pq.ParquetFile(io.BytesIO(raw))
             sample = pf.read_row_groups([0]).slice(0, 100)
-            return _coerce_timestamps(sample)
+            return coerce_timestamps(sample)
 
         raise ValueError(over_limit_msg)
 
@@ -812,7 +812,7 @@ class DetailPanel(VerticalScroll):
                 schema_table.add_row(field.name, str(field.type), "✓" if field.nullable else "✗")
 
             # Sample data (first 100 rows)
-            sample = _coerce_timestamps(pf.read_row_groups([0]).slice(0, 100))
+            sample = coerce_timestamps(pf.read_row_groups([0]).slice(0, 100))
             self.mount(Label("Data (first 100 rows)", classes="detail-title"))
             data_table = DataTable(classes="preview-content")
             self.mount(data_table)

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -29,6 +29,7 @@ from textual.widgets import (
 
 from onelake_client import OneLakeClient
 from onelake_client.exceptions import FileTooLargeError
+from onelake_client.tables.delta import _coerce_timestamps
 from onelake_tui.nodes import FileNode, FolderNode, TableNode
 from onelake_tui.sprite import OneLakeSprite, get_welcome
 
@@ -600,7 +601,8 @@ class DetailPanel(VerticalScroll):
                 continue
 
             pf = pq.ParquetFile(io.BytesIO(raw))
-            return pf.read_row_groups([0]).slice(0, 100)
+            sample = pf.read_row_groups([0]).slice(0, 100)
+            return _coerce_timestamps(sample)
 
         raise ValueError(over_limit_msg)
 
@@ -810,7 +812,7 @@ class DetailPanel(VerticalScroll):
                 schema_table.add_row(field.name, str(field.type), "✓" if field.nullable else "✗")
 
             # Sample data (first 100 rows)
-            sample = pf.read_row_groups([0]).slice(0, 100)
+            sample = _coerce_timestamps(pf.read_row_groups([0]).slice(0, 100))
             self.mount(Label("Data (first 100 rows)", classes="detail-title"))
             data_table = DataTable(classes="preview-content")
             self.mount(data_table)

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -799,6 +799,39 @@ class TestReadSample:
         ]
         mock_dataset.head.assert_called_once_with(1)
 
+    @pytest.mark.asyncio()
+    async def test_read_sample_arrow_invalid_fallback(self, auth):
+        """read_sample falls back to fragment reads on ArrowInvalid."""
+        import pyarrow as pa
+
+        # Simulate: ds.head() raises ArrowInvalid (schema mismatch)
+        mock_dataset = MagicMock()
+        mock_dataset.head.side_effect = pa.lib.ArrowInvalid(
+            "Casting from timestamp[ns] to timestamp[us, tz=UTC] would lose data"
+        )
+
+        # Fragment returns ns batch via physical schema
+        ns_arr = pa.array([-4852116231933723624], type=pa.timestamp("ns", tz="UTC"))
+        batch = pa.record_batch({"ts": ns_arr, "v": pa.array([1])})
+
+        mock_fragment = MagicMock()
+        mock_fragment.physical_schema = batch.schema
+        mock_fragment.to_batches.return_value = iter([batch])
+
+        mock_dataset.get_fragments.return_value = iter([mock_fragment])
+
+        dt_mock = MagicMock()
+        dt_mock.to_pyarrow_dataset.return_value = mock_dataset
+
+        reader = DeltaTableReader(auth)
+        with self._patch_reader(reader, dt_mock):
+            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=100)
+
+        # Should have coerced ns → us
+        assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+        assert result.num_rows == 1
+        mock_fragment.to_batches.assert_called_once_with(schema=batch.schema)
+
 
 # ── DeltaTableReader.read_cdf ───────────────────────────────────────────
 

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -678,8 +678,8 @@ class TestReadSample:
         assert result.num_rows == 0
 
     @pytest.mark.asyncio()
-    async def test_read_sample_downcasts_timestamp_ns(self, auth):
-        """read_sample downcasts timestamp[ns] columns via coerce_timestamps."""
+    async def test_read_sample_coerces_timestamp_ns(self, auth):
+        """read_sample coerces timestamp[ns] columns via coerce_timestamps."""
         import pyarrow as pa
 
         arr = pa.array([1_000_000_001], type=pa.timestamp("ns"))

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -577,14 +577,18 @@ class TestCoerceTimestamps:
         """Wildly out-of-range ns values don't raise — the exact bug from the screenshot."""
         import pyarrow as pa
 
-        # Value that fits in int64 but overflows when cast ns→us with safe=True
+        # Value that fits in int64 but is not divisible by 1000, so ns→us with
+        # safe=True would fail due to precision loss rather than overflow.
         corrupt_val = -(2**62)
         arr = pa.array([corrupt_val], type=pa.timestamp("ns"))
         table = pa.table({"ts": arr})
-        # safe=False means this won't raise
+        expected_ts = arr.cast(pa.timestamp("us"), safe=False)[0].as_py()
+        # _coerce_timestamps uses safe=False, so this should succeed and produce
+        # the same truncated timestamp value as Arrow's unsafe cast.
         result = _coerce_timestamps(table)
         assert result.num_rows == 1
         assert result.schema.field("ts").type == pa.timestamp("us")
+        assert result.column("ts").to_pylist() == [expected_ts]
 
     def test_leaves_us_timestamps_alone(self):
         """timestamp[us] columns are not touched."""

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -573,14 +573,14 @@ class TestCoerceTimestamps:
 
         assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
 
-    def test_corrupt_value_does_not_crash(self):
-        """In-range ns values that lose precision with safe=True are handled safely."""
+    def test_in_range_ns_precision_truncation_does_not_crash(self):
+        """In-range ns values that fail safe=True are truncated safely (not nullified)."""
         import pyarrow as pa
 
         # In-range int64/timestamp[ns] value that is not divisible by 1000, so
         # safe=True would fail due to precision loss rather than overflow.
-        corrupt_val = -(2**62)
-        arr = pa.array([corrupt_val], type=pa.timestamp("ns"))
+        in_range_precision_loss_val = -(2**62)
+        arr = pa.array([in_range_precision_loss_val], type=pa.timestamp("ns"))
         table = pa.table({"ts": arr})
         expected_ts = arr.cast(pa.timestamp("us"), safe=False)[0].as_py()
         # coerce_timestamps uses safe=False, so this should succeed and produce

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -574,10 +574,10 @@ class TestCoerceTimestamps:
         assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
 
     def test_corrupt_value_does_not_crash(self):
-        """Wildly out-of-range ns values don't raise — the exact bug from the screenshot."""
+        """In-range ns values that lose precision with safe=True are handled safely."""
         import pyarrow as pa
 
-        # Value that fits in int64 but is not divisible by 1000, so ns→us with
+        # In-range int64/timestamp[ns] value that is not divisible by 1000, so
         # safe=True would fail due to precision loss rather than overflow.
         corrupt_val = -(2**62)
         arr = pa.array([corrupt_val], type=pa.timestamp("ns"))
@@ -676,6 +676,30 @@ class TestReadSample:
 
         assert result == mock_table
         assert result.num_rows == 0
+
+    @pytest.mark.asyncio()
+    async def test_read_sample_downcasts_timestamp_ns(self, auth):
+        """read_sample downcasts timestamp[ns] columns via coerce_timestamps."""
+        import pyarrow as pa
+
+        arr = pa.array([1_000_000_001], type=pa.timestamp("ns"))
+        table = pa.table({"ts": arr, "v": [1]})
+
+        mock_dataset = MagicMock()
+        mock_dataset.head.return_value = table
+
+        dt_mock = MagicMock()
+        dt_mock.to_pyarrow_dataset.return_value = mock_dataset
+
+        reader = DeltaTableReader(auth)
+        with self._patch_reader(reader, dt_mock):
+            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=1)
+
+        assert result.schema.field("ts").type == pa.timestamp("us")
+        assert result.column("ts").to_pylist() == [
+            arr.cast(pa.timestamp("us"), safe=False)[0].as_py()
+        ]
+        mock_dataset.head.assert_called_once_with(1)
 
 
 # ── DeltaTableReader.read_cdf ───────────────────────────────────────────

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -909,10 +909,12 @@ class TestTimestampCoercionE2E:
             path = f"{tmp}/test.parquet"
             pq.write_table(table, path)
 
-            us_schema = pa.schema([
-                ("ts", pa.timestamp("us", tz="UTC")),
-                ("val", pa.int64()),
-            ])
+            us_schema = pa.schema(
+                [
+                    ("ts", pa.timestamp("us", tz="UTC")),
+                    ("val", pa.int64()),
+                ]
+            )
             ds = pad.dataset(path, schema=us_schema)
             with pytest.raises(pa.lib.ArrowInvalid, match="would lose data"):
                 ds.head(1)
@@ -933,10 +935,12 @@ class TestTimestampCoercionE2E:
             path = f"{tmp}/test.parquet"
             pq.write_table(table, path)
 
-            us_schema = pa.schema([
-                ("ts", pa.timestamp("us", tz="UTC")),
-                ("val", pa.int64()),
-            ])
+            us_schema = pa.schema(
+                [
+                    ("ts", pa.timestamp("us", tz="UTC")),
+                    ("val", pa.int64()),
+                ]
+            )
             ds = pad.dataset(path, schema=us_schema)
 
             # Fragment-level read with physical schema should work
@@ -964,10 +968,12 @@ class TestTimestampCoercionE2E:
             path = f"{tmp}/test.parquet"
             pq.write_table(table, path)
 
-            us_schema = pa.schema([
-                ("ts", pa.timestamp("us", tz="UTC")),
-                ("val", pa.int64()),
-            ])
+            us_schema = pa.schema(
+                [
+                    ("ts", pa.timestamp("us", tz="UTC")),
+                    ("val", pa.int64()),
+                ]
+            )
             ds = pad.dataset(path, schema=us_schema)
 
             # Simulate the read_sample fallback path
@@ -1002,10 +1008,12 @@ class TestTimestampCoercionE2E:
             path = f"{tmp}/test.parquet"
             pq.write_table(table, path)
 
-            us_schema = pa.schema([
-                ("ts", pa.timestamp("us", tz="UTC")),
-                ("name", pa.utf8()),
-            ])
+            us_schema = pa.schema(
+                [
+                    ("ts", pa.timestamp("us", tz="UTC")),
+                    ("name", pa.utf8()),
+                ]
+            )
             ds = pad.dataset(path, schema=us_schema)
 
             # Confirm it would fail without the fix

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -606,8 +606,8 @@ class TestCoerceTimestamps:
         sentinel = MagicMock(name="not-a-table")
         assert coerce_timestamps(sentinel) is sentinel
 
-    def test_out_of_range_values_nullified(self):
-        """Timestamps outside year 0001–9999 become null after coercion."""
+    def test_in_range_ns_values_survive_coercion(self):
+        """All int64 ns timestamps map to years 1677–2262 (within 0001–9999), so survive."""
         import pyarrow as pa
 
         # int64 max as timestamp[ns] represents year ~2262 — within range.
@@ -657,7 +657,7 @@ class TestNullifyOutOfRange:
         """int64 min as timestamp[us] (year ~-294215) is nullified."""
         import pyarrow as pa
 
-        arr = pa.array([-(2**63 - 1)], type=pa.int64()).cast(pa.timestamp("us"))
+        arr = pa.array([-(2**63)], type=pa.int64()).cast(pa.timestamp("us"))
         result = _nullify_out_of_range(arr, pa.timestamp("us"))
         assert result[0].as_py() is None
 
@@ -834,21 +834,21 @@ class TestReadSample:
 
     @pytest.mark.asyncio()
     async def test_read_sample_arrow_invalid_non_timestamp_propagates(self, auth):
-        """ArrowInvalid errors NOT from timestamp casting should still propagate."""
+        """ArrowInvalid errors NOT from timestamp casting should propagate."""
         import pyarrow as pa
 
         mock_dataset = MagicMock()
         mock_dataset.head.side_effect = pa.lib.ArrowInvalid("Integer overflow")
-        mock_dataset.get_fragments.return_value = iter([])
 
         dt_mock = MagicMock()
         dt_mock.to_pyarrow_dataset.return_value = mock_dataset
 
         reader = DeltaTableReader(auth)
-        with self._patch_reader(reader, dt_mock):
-            # Should return empty table, not propagate (we catch all ArrowInvalid)
-            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=100)
-        assert result.num_rows == 0
+        with (
+            self._patch_reader(reader, dt_mock),
+            pytest.raises(pa.lib.ArrowInvalid, match="Integer overflow"),
+        ):
+            await reader.read_sample("ws", "LH.Lakehouse", "t", limit=100)
 
     @pytest.mark.asyncio()
     async def test_read_sample_multi_fragment_respects_limit(self, auth):
@@ -856,7 +856,9 @@ class TestReadSample:
         import pyarrow as pa
 
         mock_dataset = MagicMock()
-        mock_dataset.head.side_effect = pa.lib.ArrowInvalid("would lose data")
+        mock_dataset.head.side_effect = pa.lib.ArrowInvalid(
+            "Casting from timestamp[ns] to timestamp[us] would lose data"
+        )
 
         # Two fragments, 3 rows each
         def make_fragment(values):

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -14,6 +14,7 @@ from onelake_client.models.table import DeltaTableInfo
 from onelake_client.tables.delta import (
     DeltaTableReader,
     _build_table_uri,
+    _coerce_timestamps,
     _run_delta_subprocess,
     _schema_to_columns,
 )
@@ -531,6 +532,69 @@ class TestRunDeltaSubprocess:
 
         assert result["ok"] is False
         assert "No files in log" in result["error"]
+
+
+# ── _coerce_timestamps ──────────────────────────────────────────────────
+
+
+class TestCoerceTimestamps:
+    """Test that ns-precision timestamps are safely downcast to us."""
+
+    def test_no_op_without_timestamp_ns(self):
+        """Tables without timestamp[ns] columns pass through unchanged."""
+        import pyarrow as pa
+
+        table = pa.table({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+        result = _coerce_timestamps(table)
+        assert result.equals(table)
+
+    def test_casts_ns_to_us(self):
+        """timestamp[ns] columns are cast to timestamp[us]."""
+        import pyarrow as pa
+
+        arr = pa.array([1_000_000_000, 2_000_000_000], type=pa.timestamp("ns"))
+        table = pa.table({"ts": arr, "val": [10, 20]})
+        result = _coerce_timestamps(table)
+
+        assert result.schema.field("ts").type == pa.timestamp("us")
+        assert result.schema.field("val").type == pa.int64()
+        assert result.column("ts").to_pylist() == [
+            pa.array([1_000_000_000], type=pa.timestamp("ns")).cast(pa.timestamp("us"))[0].as_py(),
+            pa.array([2_000_000_000], type=pa.timestamp("ns")).cast(pa.timestamp("us"))[0].as_py(),
+        ]
+
+    def test_preserves_tz(self):
+        """Timezone is preserved during the cast."""
+        import pyarrow as pa
+
+        arr = pa.array([1_000_000_000], type=pa.timestamp("ns", tz="UTC"))
+        table = pa.table({"ts": arr})
+        result = _coerce_timestamps(table)
+
+        assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+
+    def test_corrupt_value_does_not_crash(self):
+        """Wildly out-of-range ns values don't raise — the exact bug from the screenshot."""
+        import pyarrow as pa
+
+        # Value that fits in int64 but overflows when cast ns→us with safe=True
+        corrupt_val = -(2**62)
+        arr = pa.array([corrupt_val], type=pa.timestamp("ns"))
+        table = pa.table({"ts": arr})
+        # safe=False means this won't raise
+        result = _coerce_timestamps(table)
+        assert result.num_rows == 1
+        assert result.schema.field("ts").type == pa.timestamp("us")
+
+    def test_leaves_us_timestamps_alone(self):
+        """timestamp[us] columns are not touched."""
+        import pyarrow as pa
+
+        arr = pa.array([1_000_000], type=pa.timestamp("us"))
+        table = pa.table({"ts": arr})
+        result = _coerce_timestamps(table)
+        assert result.schema.field("ts").type == pa.timestamp("us")
+        assert result.equals(table)
 
 
 # ── DeltaTableReader.read_sample ────────────────────────────────────────

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -832,6 +832,196 @@ class TestReadSample:
         assert result.num_rows == 1
         mock_fragment.to_batches.assert_called_once_with(schema=batch.schema)
 
+    @pytest.mark.asyncio()
+    async def test_read_sample_arrow_invalid_non_timestamp_propagates(self, auth):
+        """ArrowInvalid errors NOT from timestamp casting should still propagate."""
+        import pyarrow as pa
+
+        mock_dataset = MagicMock()
+        mock_dataset.head.side_effect = pa.lib.ArrowInvalid("Integer overflow")
+        mock_dataset.get_fragments.return_value = iter([])
+
+        dt_mock = MagicMock()
+        dt_mock.to_pyarrow_dataset.return_value = mock_dataset
+
+        reader = DeltaTableReader(auth)
+        with self._patch_reader(reader, dt_mock):
+            # Should return empty table, not propagate (we catch all ArrowInvalid)
+            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=100)
+        assert result.num_rows == 0
+
+    @pytest.mark.asyncio()
+    async def test_read_sample_multi_fragment_respects_limit(self, auth):
+        """Fallback path reads across fragments and respects the limit."""
+        import pyarrow as pa
+
+        mock_dataset = MagicMock()
+        mock_dataset.head.side_effect = pa.lib.ArrowInvalid("would lose data")
+
+        # Two fragments, 3 rows each
+        def make_fragment(values):
+            arr = pa.array(values, type=pa.timestamp("ns"))
+            batch = pa.record_batch({"ts": arr})
+            frag = MagicMock()
+            frag.physical_schema = batch.schema
+            frag.to_batches.return_value = iter([batch])
+            return frag
+
+        frag1 = make_fragment([1_000_000_000, 2_000_000_000, 3_000_000_000])
+        frag2 = make_fragment([4_000_000_000, 5_000_000_000, 6_000_000_000])
+
+        mock_dataset.get_fragments.return_value = iter([frag1, frag2])
+
+        dt_mock = MagicMock()
+        dt_mock.to_pyarrow_dataset.return_value = mock_dataset
+
+        reader = DeltaTableReader(auth)
+        with self._patch_reader(reader, dt_mock):
+            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=4)
+
+        assert result.num_rows == 4
+        assert result.schema.field("ts").type == pa.timestamp("us")
+
+
+# ── End-to-end timestamp coercion (real parquet) ───────────────────────
+
+
+class TestTimestampCoercionE2E:
+    """End-to-end tests using real parquet files and pyarrow datasets.
+
+    These tests write actual parquet data with timestamp[ns] columns,
+    read through a dataset with a timestamp[us] schema (simulating
+    the Delta schema mismatch), and verify the full pipeline.
+    """
+
+    def test_dataset_schema_mismatch_triggers_arrow_invalid(self):
+        """Confirm that the schema mismatch actually causes ArrowInvalid."""
+        import tempfile
+
+        import pyarrow as pa
+        import pyarrow.dataset as pad
+        import pyarrow.parquet as pq
+
+        arr = pa.array([-4852116231933723624], type=pa.timestamp("ns", tz="UTC"))
+        table = pa.table({"ts": arr, "val": [1]})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/test.parquet"
+            pq.write_table(table, path)
+
+            us_schema = pa.schema([
+                ("ts", pa.timestamp("us", tz="UTC")),
+                ("val", pa.int64()),
+            ])
+            ds = pad.dataset(path, schema=us_schema)
+            with pytest.raises(pa.lib.ArrowInvalid, match="would lose data"):
+                ds.head(1)
+
+    def test_fragment_physical_schema_bypasses_cast(self):
+        """Reading fragments with physical schema preserves ns timestamps."""
+        import tempfile
+
+        import pyarrow as pa
+        import pyarrow.dataset as pad
+        import pyarrow.parquet as pq
+
+        problematic_val = -4852116231933723624
+        arr = pa.array([problematic_val], type=pa.timestamp("ns", tz="UTC"))
+        table = pa.table({"ts": arr, "val": [1]})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/test.parquet"
+            pq.write_table(table, path)
+
+            us_schema = pa.schema([
+                ("ts", pa.timestamp("us", tz="UTC")),
+                ("val", pa.int64()),
+            ])
+            ds = pad.dataset(path, schema=us_schema)
+
+            # Fragment-level read with physical schema should work
+            fragments = list(ds.get_fragments())
+            assert len(fragments) == 1
+
+            batches = list(fragments[0].to_batches(schema=fragments[0].physical_schema))
+            result = pa.Table.from_batches(batches)
+            assert result.schema.field("ts").type == pa.timestamp("ns", tz="UTC")
+            assert result.num_rows == 1
+
+    def test_full_pipeline_problematic_value(self):
+        """The exact value from production flows through fragment-read → coerce."""
+        import tempfile
+
+        import pyarrow as pa
+        import pyarrow.dataset as pad
+        import pyarrow.parquet as pq
+
+        problematic_val = -4852116231933723624
+        arr = pa.array([problematic_val], type=pa.timestamp("ns", tz="UTC"))
+        table = pa.table({"ts": arr, "val": [1]})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/test.parquet"
+            pq.write_table(table, path)
+
+            us_schema = pa.schema([
+                ("ts", pa.timestamp("us", tz="UTC")),
+                ("val", pa.int64()),
+            ])
+            ds = pad.dataset(path, schema=us_schema)
+
+            # Simulate the read_sample fallback path
+            fragments = list(ds.get_fragments())
+            batches = list(fragments[0].to_batches(schema=fragments[0].physical_schema))
+            raw_table = pa.Table.from_batches(batches)
+
+            # Apply coerce_timestamps (ns → us with safe=False + nullify)
+            result = coerce_timestamps(raw_table)
+            assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+            assert result.num_rows == 1
+            # Value should survive (it's year ~1816, within 0001–9999)
+            assert result.column("ts").to_pylist()[0] is not None
+
+    def test_full_pipeline_mixed_valid_and_problematic(self):
+        """Mix of normal and problematic ns timestamps all survive coercion."""
+        import tempfile
+
+        import pyarrow as pa
+        import pyarrow.dataset as pad
+        import pyarrow.parquet as pq
+
+        values = [
+            1_704_067_200_000_000_000,  # 2024-01-01 (normal)
+            -4852116231933723624,  # ~1816 (problematic for safe cast)
+            0,  # epoch
+        ]
+        arr = pa.array(values, type=pa.timestamp("ns", tz="UTC"))
+        table = pa.table({"ts": arr, "name": ["a", "b", "c"]})
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = f"{tmp}/test.parquet"
+            pq.write_table(table, path)
+
+            us_schema = pa.schema([
+                ("ts", pa.timestamp("us", tz="UTC")),
+                ("name", pa.utf8()),
+            ])
+            ds = pad.dataset(path, schema=us_schema)
+
+            # Confirm it would fail without the fix
+            with pytest.raises(pa.lib.ArrowInvalid):
+                ds.head(3)
+
+            # Fragment-read → coerce should work
+            fragments = list(ds.get_fragments())
+            batches = list(fragments[0].to_batches(schema=fragments[0].physical_schema))
+            result = coerce_timestamps(pa.Table.from_batches(batches))
+
+            assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
+            assert result.num_rows == 3
+            ts_values = result.column("ts").to_pylist()
+            assert all(v is not None for v in ts_values)
+
 
 # ── DeltaTableReader.read_cdf ───────────────────────────────────────────
 

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -629,6 +629,22 @@ class TestCoerceTimestamps:
         assert result.column("ts").to_pylist()[0] is not None
         assert result.schema.field("ts").type == pa.timestamp("us")
 
+    def test_preexisting_nulls_survive(self):
+        """Pre-existing None values in timestamp[ns] columns are preserved."""
+        import pyarrow as pa
+
+        arr = pa.array(
+            [1_704_067_200_000_000_000, None, 1_000_000_000],
+            type=pa.timestamp("ns"),
+        )
+        table = pa.table({"ts": arr, "v": [1, 2, 3]})
+        result = coerce_timestamps(table)
+        ts_values = result.column("ts").to_pylist()
+        assert ts_values[0] is not None
+        assert ts_values[1] is None
+        assert ts_values[2] is not None
+        assert result.schema.field("ts").type == pa.timestamp("us")
+
 
 # ── _nullify_out_of_range ──────────────────────────────────────────────
 

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -610,7 +610,7 @@ class TestCoerceTimestamps:
         """All int64 ns timestamps map to years 1677–2262 (within 0001–9999), so survive."""
         import pyarrow as pa
 
-        # int64 max as timestamp[ns] represents year ~2262 — within range.
+        # 2**62 is a large timestamp[ns] value (~year 1823) — within range.
         # After ns→us cast (÷1000), it stays in range, so it should survive.
         arr_in_range = pa.array([2**62], type=pa.timestamp("ns"))
         table_ok = pa.table({"ts": arr_in_range})

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -900,6 +900,39 @@ class TestReadSample:
         assert result.num_rows == 4
         assert result.schema.field("ts").type == pa.timestamp("us")
 
+    @pytest.mark.asyncio()
+    async def test_read_sample_fallback_stops_after_ten_fragments(self, auth):
+        """Fallback path reads at most 10 fragments even if limit is not met."""
+        import pyarrow as pa
+
+        mock_dataset = MagicMock()
+        mock_dataset.head.side_effect = pa.lib.ArrowInvalid(
+            "Casting from timestamp[ns] to timestamp[us] would lose data"
+        )
+
+        fragments = []
+        for i in range(12):
+            batch = pa.record_batch({"ts": pa.array([i], type=pa.timestamp("ns"))})
+            frag = MagicMock()
+            frag.physical_schema = batch.schema
+            frag.to_batches.return_value = iter([batch])
+            fragments.append(frag)
+
+        mock_dataset.get_fragments.return_value = iter(fragments)
+
+        dt_mock = MagicMock()
+        dt_mock.to_pyarrow_dataset.return_value = mock_dataset
+
+        reader = DeltaTableReader(auth)
+        with self._patch_reader(reader, dt_mock):
+            result = await reader.read_sample("ws", "LH.Lakehouse", "t", limit=100)
+
+        # Only first 10 fragments should be read
+        assert result.num_rows == 10
+        assert fragments[9].to_batches.called
+        assert not fragments[10].to_batches.called
+        assert not fragments[11].to_batches.called
+
 
 # ── End-to-end timestamp coercion (real parquet) ───────────────────────
 

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -14,9 +14,9 @@ from onelake_client.models.table import DeltaTableInfo
 from onelake_client.tables.delta import (
     DeltaTableReader,
     _build_table_uri,
-    _coerce_timestamps,
     _run_delta_subprocess,
     _schema_to_columns,
+    coerce_timestamps,
 )
 
 # ── Fixtures ────────────────────────────────────────────────────────────
@@ -534,7 +534,7 @@ class TestRunDeltaSubprocess:
         assert "No files in log" in result["error"]
 
 
-# ── _coerce_timestamps ──────────────────────────────────────────────────
+# ── coerce_timestamps ───────────────────────────────────────────────────
 
 
 class TestCoerceTimestamps:
@@ -545,7 +545,7 @@ class TestCoerceTimestamps:
         import pyarrow as pa
 
         table = pa.table({"x": [1, 2, 3], "y": ["a", "b", "c"]})
-        result = _coerce_timestamps(table)
+        result = coerce_timestamps(table)
         assert result.equals(table)
 
     def test_casts_ns_to_us(self):
@@ -554,7 +554,7 @@ class TestCoerceTimestamps:
 
         arr = pa.array([1_000_000_000, 2_000_000_000], type=pa.timestamp("ns"))
         table = pa.table({"ts": arr, "val": [10, 20]})
-        result = _coerce_timestamps(table)
+        result = coerce_timestamps(table)
 
         assert result.schema.field("ts").type == pa.timestamp("us")
         assert result.schema.field("val").type == pa.int64()
@@ -569,7 +569,7 @@ class TestCoerceTimestamps:
 
         arr = pa.array([1_000_000_000], type=pa.timestamp("ns", tz="UTC"))
         table = pa.table({"ts": arr})
-        result = _coerce_timestamps(table)
+        result = coerce_timestamps(table)
 
         assert result.schema.field("ts").type == pa.timestamp("us", tz="UTC")
 
@@ -583,9 +583,9 @@ class TestCoerceTimestamps:
         arr = pa.array([corrupt_val], type=pa.timestamp("ns"))
         table = pa.table({"ts": arr})
         expected_ts = arr.cast(pa.timestamp("us"), safe=False)[0].as_py()
-        # _coerce_timestamps uses safe=False, so this should succeed and produce
+        # coerce_timestamps uses safe=False, so this should succeed and produce
         # the same truncated timestamp value as Arrow's unsafe cast.
-        result = _coerce_timestamps(table)
+        result = coerce_timestamps(table)
         assert result.num_rows == 1
         assert result.schema.field("ts").type == pa.timestamp("us")
         assert result.column("ts").to_pylist() == [expected_ts]
@@ -596,7 +596,7 @@ class TestCoerceTimestamps:
 
         arr = pa.array([1_000_000], type=pa.timestamp("us"))
         table = pa.table({"ts": arr})
-        result = _coerce_timestamps(table)
+        result = coerce_timestamps(table)
         assert result.schema.field("ts").type == pa.timestamp("us")
         assert result.equals(table)
 

--- a/TUI/tests/test_delta_reader.py
+++ b/TUI/tests/test_delta_reader.py
@@ -14,6 +14,7 @@ from onelake_client.models.table import DeltaTableInfo
 from onelake_client.tables.delta import (
     DeltaTableReader,
     _build_table_uri,
+    _nullify_out_of_range,
     _run_delta_subprocess,
     _schema_to_columns,
     coerce_timestamps,
@@ -600,8 +601,105 @@ class TestCoerceTimestamps:
         assert result.schema.field("ts").type == pa.timestamp("us")
         assert result.equals(table)
 
+    def test_non_pyarrow_table_passes_through(self):
+        """Non-pyarrow objects (e.g. MagicMock) are returned unchanged."""
+        sentinel = MagicMock(name="not-a-table")
+        assert coerce_timestamps(sentinel) is sentinel
 
-# ── DeltaTableReader.read_sample ────────────────────────────────────────
+    def test_out_of_range_values_nullified(self):
+        """Timestamps outside year 0001–9999 become null after coercion."""
+        import pyarrow as pa
+
+        # int64 max as timestamp[ns] represents year ~2262 — within range.
+        # After ns→us cast (÷1000), it stays in range, so it should survive.
+        arr_in_range = pa.array([2**62], type=pa.timestamp("ns"))
+        table_ok = pa.table({"ts": arr_in_range})
+        result = coerce_timestamps(table_ok)
+        assert result.column("ts").to_pylist()[0] is not None
+
+    def test_ns_values_within_valid_range_survive(self):
+        """Normal ns timestamps survive coercion with correct values."""
+        import pyarrow as pa
+
+        # 2024-01-01T00:00:00 in nanoseconds from epoch
+        ns_val = 1_704_067_200_000_000_000
+        arr = pa.array([ns_val], type=pa.timestamp("ns"))
+        table = pa.table({"ts": arr})
+        result = coerce_timestamps(table)
+        assert result.column("ts").to_pylist()[0] is not None
+        assert result.schema.field("ts").type == pa.timestamp("us")
+
+
+# ── _nullify_out_of_range ──────────────────────────────────────────────
+
+
+class TestNullifyOutOfRange:
+    """Test that out-of-range timestamps are replaced with null."""
+
+    def test_in_range_values_preserved(self):
+        """Timestamps within year 0001–9999 are preserved."""
+        import pyarrow as pa
+
+        # 2024-01-01 in µs from epoch
+        arr = pa.array([1_704_067_200_000_000], type=pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        assert result.to_pylist() == arr.to_pylist()
+
+    def test_extreme_positive_nullified(self):
+        """int64 max as timestamp[us] (year ~294247) is nullified."""
+        import pyarrow as pa
+
+        arr = pa.array([2**63 - 1], type=pa.int64()).cast(pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        assert result[0].as_py() is None
+
+    def test_extreme_negative_nullified(self):
+        """int64 min as timestamp[us] (year ~-294215) is nullified."""
+        import pyarrow as pa
+
+        arr = pa.array([-(2**63 - 1)], type=pa.int64()).cast(pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        assert result[0].as_py() is None
+
+    def test_boundary_year_0001_preserved(self):
+        """Timestamp at year 0001-01-01 is within range."""
+        import pyarrow as pa
+
+        # Year 0001-01-01T00:00:00 = -62135596800 seconds from epoch
+        us_val = -62_135_596_800_000_000
+        arr = pa.array([us_val], type=pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        assert result[0].as_py() is not None
+
+    def test_boundary_year_9999_preserved(self):
+        """Timestamp at year 9999-12-31 is within range."""
+        import pyarrow as pa
+
+        us_val = 253_402_300_799_999_999
+        arr = pa.array([us_val], type=pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        assert result[0].as_py() is not None
+
+    def test_preserves_tz(self):
+        """Timezone-aware timestamps are handled correctly."""
+        import pyarrow as pa
+
+        arr = pa.array([2**63 - 1], type=pa.int64()).cast(pa.timestamp("us", tz="UTC"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us", tz="UTC"))
+        assert result[0].as_py() is None
+        assert result.type == pa.timestamp("us", tz="UTC")
+
+    def test_mixed_valid_and_invalid(self):
+        """Mix of valid and out-of-range values: only out-of-range become null."""
+        import pyarrow as pa
+
+        valid_us = 1_704_067_200_000_000  # 2024-01-01
+        invalid_us = 2**63 - 1  # far future
+        arr = pa.array([valid_us, invalid_us], type=pa.int64()).cast(pa.timestamp("us"))
+        result = _nullify_out_of_range(arr, pa.timestamp("us"))
+        values = result.to_pylist()
+        assert values[0] is not None
+        assert values[1] is None
 
 
 class TestReadSample:


### PR DESCRIPTION
## Summary

Fixes #19 — Data preview crashes on Delta tables whose parquet files contain `timestamp[ns]` columns.

## Problem

`DeltaTableReader.read_sample()` calls `dt.to_pyarrow_dataset().head(limit)`, which internally casts `timestamp[ns]` → `timestamp[us, tz=UTC]` with `safe=True`. PyArrow rejects this for values that cannot be losslessly represented in microseconds (e.g. values like `-4852116231933723624` whose nanosecond component is not divisible by 1000), producing:

```
❌ Data preview failed: Casting from timestamp[ns] to timestamp[us, tz=UTC] would lose data
```

## Solution

### 1. ArrowInvalid fallback in `read_sample()`
When `ds.head()` raises `ArrowInvalid` for the timestamp cast failure, falls back to reading parquet fragments using their physical schema (which preserves `timestamp[ns]`). Limited to 10 fragments for performance safety.

### 2. `coerce_timestamps()` public helper
Scans a pyarrow Table for `timestamp[ns]` columns and casts them to `timestamp[us]` with `safe=False` (truncates sub-microsecond precision). Applied to all three read paths:
- `DeltaTableReader.read_sample()` — Delta Data tab preview
- `_read_parquet_fallback()` — fallback parquet preview
- `_preview_parquet()` — direct parquet file preview

### 3. `_nullify_out_of_range()` defensive guard
After casting, timestamps outside year 0001–9999 are replaced with null. For the ns→us path this is defensive (all int64 ns values map to years 1677–2262), but provides a safety net for future use.

## Test coverage

341 tests pass. New tests include:

**Unit tests (TestCoerceTimestamps — 9 tests):** ns→us cast, timezone preservation, MagicMock passthrough, pre-existing nulls, in-range survival

**Unit tests (TestNullifyOutOfRange — 7 tests):** boundary values (year 0001, 9999), extreme int64 values, mixed valid/invalid, timezone handling

**Integration tests (TestReadSample — 7 tests):** happy path, limit, empty, coercion, ArrowInvalid fallback with real fragment mocks, multi-fragment limit, non-timestamp error propagation

**End-to-end tests (TestTimestampCoercionE2E — 4 tests):** Real parquet files written with timestamp[ns], read through timestamp[us] dataset schema, the exact production value `-4852116231933723624`, mixed rows

## Also included

- CI job enforcing `CHANGELOG.md` updates on user-facing PRs (skip with `chore` or `documentation` label)
- Code-review instructions (`.github/instructions/code-review.instructions.md`)
- Copilot instructions updated with timestamp coercion convention

## Checklist

- [x] All 341 tests pass
- [x] Lint + format clean (`ruff check` + `ruff format`)
- [x] CHANGELOG updated
- [x] Verified against real Fabric data — preview loads correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public timestamp-coercion helper to make data previews resilient to ns→us timestamp mismatches.

* **Bug Fixes**
  * Fixed crashes when previewing tables with nanosecond timestamps by downcasting and nullifying out-of-range values; added a safe fallback read path.

* **Chores**
  * Added CI enforcement requiring changelog entries for user-facing PRs.

* **Documentation**
  * Updated contributor instructions to require changelog and docs updates for user-facing changes.

* **Tests**
  * Added comprehensive tests covering coercion and preview fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->