### PR TITLE
feat: add Delta Analysis tab with parquet file, row group, column chu…

### DIFF
--- a/TUI/src/onelake_client/dfs/client.py
+++ b/TUI/src/onelake_client/dfs/client.py
@@ -206,6 +206,32 @@ class DfsClient:
 
         return response.content
 
+    async def read_file_tail(self, workspace: str, path: str, tail_bytes: int) -> bytes:
+        """Read the last *tail_bytes* bytes of a file using an HTTP Range request.
+
+        Used for efficiently reading parquet file footers without downloading
+        the entire file.
+
+        Args:
+            workspace: Workspace name or GUID.
+            path: Full path within the workspace.
+            tail_bytes: Number of bytes to read from the end of the file.
+
+        Returns:
+            The last *tail_bytes* bytes of the file.
+        """
+        client = await self._get_client()
+        headers = _dfs_headers(self._auth.dfs_headers())
+        headers["Range"] = f"bytes=-{tail_bytes}"
+
+        response = await request_with_retry(
+            client,
+            "GET",
+            f"{self._base_url}/{workspace}/{path}",
+            headers=headers,
+        )
+        return response.content
+
     async def read_file_stream(
         self, workspace: str, path: str, *, chunk_size: int = 65536
     ) -> AsyncIterator[bytes]:

--- a/TUI/src/onelake_client/models/__init__.py
+++ b/TUI/src/onelake_client/models/__init__.py
@@ -1,17 +1,35 @@
 from onelake_client.models.filesystem import FileProperties, PathInfo
 from onelake_client.models.item import Item, Lakehouse, LakehouseProperties, SqlEndpointProperties
-from onelake_client.models.table import Column, DeltaTableInfo, IcebergTableInfo
+from onelake_client.models.table import (
+    Column,
+    ColumnChunkInfo,
+    ColumnInfo,
+    DeltaAnalysisResult,
+    DeltaAnalysisSummary,
+    DeltaFileStats,
+    DeltaTableInfo,
+    IcebergTableInfo,
+    ParquetFileInfo,
+    RowGroupInfo,
+)
 from onelake_client.models.workspace import Workspace
 
 __all__ = [
     "Column",
+    "ColumnChunkInfo",
+    "ColumnInfo",
+    "DeltaAnalysisResult",
+    "DeltaAnalysisSummary",
+    "DeltaFileStats",
     "DeltaTableInfo",
     "FileProperties",
     "IcebergTableInfo",
     "Item",
     "Lakehouse",
     "LakehouseProperties",
+    "ParquetFileInfo",
     "PathInfo",
+    "RowGroupInfo",
     "SqlEndpointProperties",
     "Workspace",
 ]

--- a/TUI/src/onelake_client/models/table.py
+++ b/TUI/src/onelake_client/models/table.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from typing import Any
 
 
 class Column(BaseModel):
@@ -7,7 +8,7 @@ class Column(BaseModel):
     name: str
     type: str
     nullable: bool = True
-    metadata: dict[str, str] | None = None
+    metadata: dict[str, Any] | None = None
     comment: str | None = None
 
 

--- a/TUI/src/onelake_client/models/table.py
+++ b/TUI/src/onelake_client/models/table.py
@@ -24,6 +24,92 @@ class DeltaTableInfo(BaseModel):
     description: str | None = None
 
 
+class DeltaFileStats(BaseModel):
+    """Per-file statistics for a Delta table derived from add actions."""
+
+    num_files: int = 0
+    total_bytes: int = 0
+    min_file_bytes: int = 0
+    max_file_bytes: int = 0
+    avg_file_bytes: float = 0.0
+    partition_counts: dict[str, int] = {}
+
+
+class ParquetFileInfo(BaseModel):
+    """Row-level metadata for a single parquet file in a Delta table."""
+
+    parquet_file: str
+    row_count: int
+    row_groups: int
+    created_by: str = ""
+    total_table_rows: int = 0
+    total_table_row_groups: int = 0
+
+
+class RowGroupInfo(BaseModel):
+    """Metadata for a single row group within a parquet file."""
+
+    parquet_file: str
+    row_group_id: int
+    row_count: int
+    compressed_size: int
+    uncompressed_size: int
+    compression_ratio: float = 0.0
+    total_table_rows: int = 0
+    ratio_of_total_rows: float = 0.0
+    total_table_row_groups: int = 0
+
+
+class ColumnChunkInfo(BaseModel):
+    """Metadata for a single column chunk within a row group."""
+
+    parquet_file: str
+    row_group_id: int
+    column_id: int
+    column_name: str
+    column_type: str
+    compressed_size: int
+    uncompressed_size: int
+    has_dict: bool = False
+    value_count: int = 0
+    encodings: str = ""
+
+
+class ColumnInfo(BaseModel):
+    """Aggregated column-level metadata across all parquet files."""
+
+    column_name: str
+    column_type: str
+    compressed_size: int
+    uncompressed_size: int
+    total_table_rows: int = 0
+    size_percent_of_table: float = 0.0
+
+
+class DeltaAnalysisSummary(BaseModel):
+    """Summary statistics for a Delta table analysis."""
+
+    row_count: int = 0
+    parquet_files: int = 0
+    row_groups: int = 0
+    max_rows_per_row_group: int = 0
+    min_rows_per_row_group: int = 0
+    avg_rows_per_row_group: float = 0.0
+    total_compressed_size: int = 0
+    files_skipped: int = 0
+    files_skipped_reason: str = ""
+
+
+class DeltaAnalysisResult(BaseModel):
+    """Full result from delta_analyzer — mirrors the 5-dataframe structure."""
+
+    summary: DeltaAnalysisSummary = DeltaAnalysisSummary()
+    parquet_files: list[ParquetFileInfo] = []
+    row_groups: list[RowGroupInfo] = []
+    column_chunks: list[ColumnChunkInfo] = []
+    columns: list[ColumnInfo] = []
+
+
 class IcebergTableInfo(BaseModel):
     """Metadata for an Iceberg table."""
 

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -41,6 +41,19 @@ def _build_table_uri(workspace: str, item_path: str, table_name: str, dfs_host: 
     return f"abfss://{workspace}@{dfs_host}/{item_path}/Tables/{table_name}"
 
 
+def _clean_type_str(t) -> str:
+    """Return a human-readable type string from a deltalake type object.
+
+    deltalake >= 1.0 wraps primitive types as PrimitiveType("string") when
+    str()-ed. This extracts just the inner name for primitives and falls back
+    to the raw string for complex types (ArrayType, MapType, StructType).
+    """
+    # PrimitiveType exposes the plain name via its .type attribute
+    if hasattr(t, "type") and isinstance(getattr(t, "type"), str):
+        return t.type
+    return str(t)
+
+
 def _schema_to_columns(schema) -> list[Column]:
     """Convert a deltalake Schema to our Column model."""
     columns: list[Column] = []
@@ -50,7 +63,7 @@ def _schema_to_columns(schema) -> list[Column]:
         columns.append(
             Column(
                 name=field.name,
-                type=str(field.type),
+                type=_clean_type_str(field.type),
                 nullable=field.nullable,
                 metadata=field.metadata if field.metadata else None,
             )
@@ -77,7 +90,7 @@ try:
     columns = [
         {
             "name": f.name,
-            "type": str(f.type),
+            "type": f.type.type if (hasattr(f.type, "type") and isinstance(getattr(f.type, "type"), str)) else str(f.type),
             "nullable": f.nullable,
             "metadata": dict(f.metadata) if f.metadata else None,
         }

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -517,6 +517,21 @@ class DeltaTableReader:
         if not result.get("ok"):
             raise DeltaError(result.get("error", "Unknown error resolving file list"))
 
+        # ── 1a. Build physical→logical column name mapping ──────────────
+        # Tables with delta.columnMapping.mode=id store columns in parquet
+        # using GUIDs (delta.columnMapping.physicalName) rather than the
+        # logical names visible in the Delta schema.
+        phys_to_logical: dict[str, str] = {}
+        try:
+            meta_info = await self.get_metadata(workspace, item_path, table_name)
+            for col in meta_info.schema_:
+                if col.metadata:
+                    phys = col.metadata.get("delta.columnMapping.physicalName")
+                    if phys is not None:
+                        phys_to_logical[str(phys)] = col.name
+        except Exception as exc:
+            logger.debug("Could not load schema for column name mapping: %s", exc)
+
         # List parquet files in the table directory via DFS (current active files)
         table_dir = f"{item_path}/Tables/{table_name}"
         dfs_paths = await dfs_client.list_paths(workspace, table_dir)
@@ -629,13 +644,14 @@ class DeltaTableReader:
                     rg_compressed += col.total_compressed_size
                     rg_uncompressed += col.total_uncompressed_size
 
+                    logical_name = phys_to_logical.get(col.path_in_schema, col.path_in_schema)
                     encodings = ", ".join(str(e) for e in col.encodings) if col.encodings else ""
                     column_chunk_infos.append(
                         ColumnChunkInfo(
                             parquet_file=file_name,
                             row_group_id=rg_idx + 1,
                             column_id=col_idx,
-                            column_name=col.path_in_schema,
+                            column_name=logical_name,
                             column_type=col.physical_type,
                             compressed_size=col.total_compressed_size,
                             uncompressed_size=col.total_uncompressed_size,

--- a/TUI/src/onelake_client/tables/delta.py
+++ b/TUI/src/onelake_client/tables/delta.py
@@ -6,7 +6,17 @@ from typing import TYPE_CHECKING
 
 from deltalake.exceptions import DeltaError
 
-from onelake_client.models.table import Column, DeltaTableInfo
+from onelake_client.models.table import (
+    Column,
+    ColumnChunkInfo,
+    ColumnInfo,
+    DeltaAnalysisResult,
+    DeltaAnalysisSummary,
+    DeltaFileStats,
+    DeltaTableInfo,
+    ParquetFileInfo,
+    RowGroupInfo,
+)
 
 if TYPE_CHECKING:
     from onelake_client.auth import OneLakeAuth
@@ -107,6 +117,57 @@ except Exception as e:
     json.dump({"ok": False, "error": f"{type(e).__name__}: {e}"}, sys.stdout)
 """
 
+_FILE_STATS_SCRIPT = """
+import sys, json
+from deltalake import DeltaTable
+
+data = json.load(sys.stdin)
+uri = data["uri"]
+storage_options = data["storage_options"]
+
+try:
+    dt = DeltaTable(uri, storage_options=storage_options)
+    add_actions = dt.get_add_actions(flatten=True)
+
+    col_names = list(add_actions.column_names) if hasattr(add_actions, "column_names") else []
+
+    size_key = "size_bytes" if "size_bytes" in col_names else "size"
+    sizes = add_actions.column(size_key).to_pylist() if size_key in col_names else []
+    valid_sizes = [s for s in sizes if s is not None and isinstance(s, (int, float))]
+
+    num_files = len(valid_sizes)
+    total_bytes = int(sum(valid_sizes))
+    min_bytes = int(min(valid_sizes)) if valid_sizes else 0
+    max_bytes = int(max(valid_sizes)) if valid_sizes else 0
+    avg_bytes = total_bytes / num_files if num_files else 0.0
+
+    partition_counts = {}
+    try:
+        meta = dt.metadata()
+        partition_cols = list(meta.partition_columns)
+        for col in partition_cols:
+            col_key = f"partition.{col}"
+            if col_key in col_names:
+                values = add_actions.column(col_key).to_pylist()
+                for v in values:
+                    label = f"{col}={v if v is not None else 'null'}"
+                    partition_counts[label] = partition_counts.get(label, 0) + 1
+    except Exception:
+        pass
+
+    json.dump({
+        "ok": True,
+        "num_files": num_files,
+        "total_bytes": total_bytes,
+        "min_file_bytes": min_bytes,
+        "max_file_bytes": max_bytes,
+        "avg_file_bytes": avg_bytes,
+        "partition_counts": partition_counts,
+    }, sys.stdout)
+except Exception as e:
+    json.dump({"ok": False, "error": f"{type(e).__name__}: {e}"}, sys.stdout)
+"""
+
 
 def _run_delta_subprocess(
     uri: str, storage_options: dict, timeout: int = _SUBPROCESS_TIMEOUT
@@ -157,6 +218,52 @@ def _run_delta_subprocess(
         return json.loads(stdout)
     except json.JSONDecodeError as exc:
         raise DeltaError(f"Delta reader returned invalid output: {stdout[:200]}") from exc
+
+
+def _run_file_stats_subprocess(
+    uri: str, storage_options: dict, timeout: int = _SUBPROCESS_TIMEOUT
+) -> dict:
+    """Run the file-stats script in a subprocess (same isolation as metadata)."""
+    import json
+    import os
+    import subprocess
+    import sys
+
+    input_data = json.dumps({"uri": uri, "storage_options": storage_options})
+    popen_kwargs: dict[str, object] = {
+        "stdin": subprocess.PIPE,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "close_fds": True,
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _FILE_STATS_SCRIPT],
+        **popen_kwargs,  # type: ignore[arg-type]
+    )
+    try:
+        stdout, stderr = proc.communicate(input=input_data, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        raise DeltaError(f"Delta file-stats timed out after {timeout}s") from None
+
+    if proc.returncode != 0:
+        err = (stderr or "").strip()
+        if len(err) > 300:
+            err = err[:300] + "…"
+        raise DeltaError(
+            f"Delta file-stats process crashed (exit code {proc.returncode}). "
+            f"{err or 'Check table compatibility.'}"
+        )
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise DeltaError(f"Delta file-stats returned invalid output: {stdout[:200]}") from exc
 
 
 class DeltaTableReader:
@@ -331,3 +438,289 @@ class DeltaTableReader:
         uri = _build_table_uri(workspace, item_path, table_name, self._dfs_host)
         dt = await asyncio.to_thread(self._load_table_sync, uri)
         return dt.file_uris()
+
+    async def get_file_stats(
+        self, workspace: str, item_path: str, table_name: str
+    ) -> DeltaFileStats:
+        """Get per-file size statistics and partition distribution for a Delta table.
+
+        Runs in a subprocess to match the same Rust-panic isolation used by
+        ``get_metadata``.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item_path: Item path like "MyLakehouse.Lakehouse".
+            table_name: Table name under Tables/.
+
+        Returns:
+            :class:`DeltaFileStats` with file count, size metrics, and
+            partition value counts.
+        """
+        uri = _build_table_uri(workspace, item_path, table_name, self._dfs_host)
+        logger.debug("Loading Delta file stats: %s", uri)
+        storage_options = self._get_storage_options()
+        result = await asyncio.to_thread(_run_file_stats_subprocess, uri, storage_options)
+
+        if not result.get("ok"):
+            raise DeltaError(result.get("error", "Unknown error in Delta file-stats reader"))
+
+        return DeltaFileStats(
+            num_files=result["num_files"],
+            total_bytes=result["total_bytes"],
+            min_file_bytes=result["min_file_bytes"],
+            max_file_bytes=result["max_file_bytes"],
+            avg_file_bytes=result["avg_file_bytes"],
+            partition_counts=result["partition_counts"],
+        )
+
+    async def get_analysis(
+        self,
+        workspace: str,
+        item_path: str,
+        table_name: str,
+        dfs_client,
+        *,
+        max_files: int = 20,
+        progress_callback=None,
+    ) -> DeltaAnalysisResult:
+        """Analyze a Delta table's parquet files: row groups, column chunks, columns.
+
+        Mirrors the 5-dataframe structure of semantic-link-labs delta_analyzer.
+        Reads only the parquet footer (HTTP Range tail read) per file — no full
+        file downloads required.
+
+        Args:
+            workspace: Workspace name or GUID.
+            item_path: Item path like "MyLakehouse.Lakehouse".
+            table_name: Table name under Tables/.
+            dfs_client: An active :class:`onelake_client.dfs.DfsClient` instance.
+            max_files: Cap on number of parquet files to inspect.
+            progress_callback: Optional ``async callable(current, total, filename)``
+                called after each file is analysed.
+
+        Returns:
+            :class:`DeltaAnalysisResult` with summary, per-file, row-group,
+            column-chunk, and aggregated column data.
+        """
+        import io
+        import struct
+
+        import pyarrow.parquet as pq
+
+        _PARQUET_MAGIC = b"PAR1"
+        _FOOTER_TAIL = 1 * 1024 * 1024  # 1 MB — enough for any realistic footer
+
+        # ── 1. Get the list of current active parquet file paths ────────
+        uri = _build_table_uri(workspace, item_path, table_name, self._dfs_host)
+        storage_options = self._get_storage_options()
+        result = await asyncio.to_thread(_run_file_stats_subprocess, uri, storage_options)
+        if not result.get("ok"):
+            raise DeltaError(result.get("error", "Unknown error resolving file list"))
+
+        # List parquet files in the table directory via DFS (current active files)
+        table_dir = f"{item_path}/Tables/{table_name}"
+        dfs_paths = await dfs_client.list_paths(workspace, table_dir)
+        parquet_paths = [
+            p for p in dfs_paths
+            if not p.is_directory and p.name.endswith(".parquet")
+        ]
+
+        # Cap to max_files
+        files_skipped = max(0, len(parquet_paths) - max_files)
+        parquet_paths = parquet_paths[:max_files]
+
+        # ── 2. Read parquet footer per file via Range request ───────────
+        parquet_file_infos: list[ParquetFileInfo] = []
+        row_group_infos: list[RowGroupInfo] = []
+        column_chunk_infos: list[ColumnChunkInfo] = []
+
+        total_row_count = 0
+        total_row_groups = 0
+        max_rows_rg = 0
+        min_rows_rg: int | None = None
+        total_compressed = 0
+
+        for idx, pinfo in enumerate(parquet_paths):
+            file_path = pinfo.name
+            file_name = file_path.split("/")[-1]
+
+            if progress_callback is not None:
+                await progress_callback(idx + 1, len(parquet_paths), file_name)
+
+            try:
+                tail = await dfs_client.read_file_tail(workspace, file_path, _FOOTER_TAIL)
+            except Exception as exc:
+                logger.debug("Failed to read tail of %s: %s", file_path, exc)
+                continue
+
+            # Validate parquet magic at end of tail
+            if len(tail) < 8 or tail[-4:] != _PARQUET_MAGIC:
+                logger.debug("Skipping %s — not a valid parquet file", file_path)
+                continue
+
+            footer_len = struct.unpack("<I", tail[-8:-4])[0]
+            footer_start = len(tail) - 8 - footer_len
+            if footer_start < 0:
+                # Footer overflows our tail; fall back to full file read
+                try:
+                    raw = await dfs_client.read_file(
+                        workspace, file_path, max_bytes=50 * 1024 * 1024
+                    )
+                    pf = pq.ParquetFile(io.BytesIO(raw))
+                except Exception as exc2:
+                    logger.debug("Fallback full read failed for %s: %s", file_path, exc2)
+                    continue
+            else:
+                footer_bytes = tail[footer_start : len(tail) - 8]
+                # Reconstruct a minimal valid parquet file buffer that pyarrow can parse:
+                # PAR1 + footer + len(footer) [4 bytes LE] + PAR1
+                fake_buf = (
+                    _PARQUET_MAGIC
+                    + footer_bytes
+                    + struct.pack("<I", footer_len)
+                    + _PARQUET_MAGIC
+                )
+                try:
+                    pf = pq.ParquetFile(io.BytesIO(fake_buf))
+                except Exception as exc3:
+                    logger.debug(
+                        "Footer-only parse failed for %s (%s), trying full read", file_path, exc3
+                    )
+                    try:
+                        raw = await dfs_client.read_file(
+                            workspace, file_path, max_bytes=50 * 1024 * 1024
+                        )
+                        pf = pq.ParquetFile(io.BytesIO(raw))
+                    except Exception as exc4:
+                        logger.debug("Full read fallback also failed: %s", exc4)
+                        continue
+
+            meta = pf.metadata
+            file_row_count = meta.num_rows
+            file_row_groups = meta.num_row_groups
+            created_by = meta.created_by or ""
+
+            parquet_file_infos.append(
+                ParquetFileInfo(
+                    parquet_file=file_name,
+                    row_count=file_row_count,
+                    row_groups=file_row_groups,
+                    created_by=created_by,
+                )
+            )
+
+            total_row_count += file_row_count
+            total_row_groups += file_row_groups
+
+            for rg_idx in range(file_row_groups):
+                rg = meta.row_group(rg_idx)
+                rg_rows = rg.num_rows
+                rg_compressed = 0
+                rg_uncompressed = 0
+
+                max_rows_rg = max(max_rows_rg, rg_rows)
+                if min_rows_rg is None:
+                    min_rows_rg = rg_rows
+                else:
+                    min_rows_rg = min(min_rows_rg, rg_rows)
+
+                for col_idx in range(rg.num_columns):
+                    col = rg.column(col_idx)
+                    rg_compressed += col.total_compressed_size
+                    rg_uncompressed += col.total_uncompressed_size
+
+                    encodings = ", ".join(str(e) for e in col.encodings) if col.encodings else ""
+                    column_chunk_infos.append(
+                        ColumnChunkInfo(
+                            parquet_file=file_name,
+                            row_group_id=rg_idx + 1,
+                            column_id=col_idx,
+                            column_name=col.path_in_schema,
+                            column_type=col.physical_type,
+                            compressed_size=col.total_compressed_size,
+                            uncompressed_size=col.total_uncompressed_size,
+                            has_dict=bool(col.has_dictionary_page),
+                            value_count=col.num_values,
+                            encodings=encodings,
+                        )
+                    )
+
+                total_compressed += rg_compressed
+                ratio = (
+                    rg_compressed / rg_uncompressed if rg_uncompressed else 0.0
+                )
+                row_group_infos.append(
+                    RowGroupInfo(
+                        parquet_file=file_name,
+                        row_group_id=rg_idx + 1,
+                        row_count=rg_rows,
+                        compressed_size=rg_compressed,
+                        uncompressed_size=rg_uncompressed,
+                        compression_ratio=ratio,
+                    )
+                )
+
+        # ── 3. Back-fill table-level totals ─────────────────────────────
+        for pfi in parquet_file_infos:
+            pfi.total_table_rows = total_row_count
+            pfi.total_table_row_groups = total_row_groups
+
+        for rgi in row_group_infos:
+            rgi.total_table_rows = total_row_count
+            rgi.total_table_row_groups = total_row_groups
+            rgi.ratio_of_total_rows = (
+                rgi.row_count / total_row_count * 100.0 if total_row_count else 0.0
+            )
+
+        # ── 4. Aggregate column-level stats ─────────────────────────────
+        col_agg: dict[tuple[str, str], dict] = {}
+        for cc in column_chunk_infos:
+            key = (cc.column_name, cc.column_type)
+            if key not in col_agg:
+                col_agg[key] = {"compressed": 0, "uncompressed": 0}
+            col_agg[key]["compressed"] += cc.compressed_size
+            col_agg[key]["uncompressed"] += cc.uncompressed_size
+
+        columns: list[ColumnInfo] = []
+        for (col_name, col_type), agg in col_agg.items():
+            pct = (
+                agg["compressed"] / total_compressed * 100.0 if total_compressed else 0.0
+            )
+            columns.append(
+                ColumnInfo(
+                    column_name=col_name,
+                    column_type=col_type,
+                    compressed_size=agg["compressed"],
+                    uncompressed_size=agg["uncompressed"],
+                    total_table_rows=total_row_count,
+                    size_percent_of_table=pct,
+                )
+            )
+        columns.sort(key=lambda c: c.compressed_size, reverse=True)
+
+        # ── 5. Build summary ─────────────────────────────────────────────
+        avg_rg = total_row_count / total_row_groups if total_row_groups else 0.0
+        skip_reason = (
+            f"{files_skipped} file(s) not analysed (capped at {max_files})"
+            if files_skipped
+            else ""
+        )
+        summary = DeltaAnalysisSummary(
+            row_count=total_row_count,
+            parquet_files=len(parquet_file_infos),
+            row_groups=total_row_groups,
+            max_rows_per_row_group=max_rows_rg,
+            min_rows_per_row_group=min_rows_rg or 0,
+            avg_rows_per_row_group=avg_rg,
+            total_compressed_size=total_compressed,
+            files_skipped=files_skipped,
+            files_skipped_reason=skip_reason,
+        )
+
+        return DeltaAnalysisResult(
+            summary=summary,
+            parquet_files=parquet_file_infos,
+            row_groups=row_group_infos,
+            column_chunks=column_chunk_infos,
+            columns=columns,
+        )

--- a/TUI/src/onelake_tui/detail.py
+++ b/TUI/src/onelake_tui/detail.py
@@ -303,6 +303,12 @@ class DetailPanel(VerticalScroll):
             await txn_pane.mount(LoadingIndicator(id="txn-loading"))
             self._load_transaction_log(data)
 
+            # ── Analysis tab ────────────────────────────────────────────
+            analysis_pane = TabPane("Analysis", id="tab-analysis")
+            await tc.add_pane(analysis_pane)
+            await analysis_pane.mount(LoadingIndicator(id="analysis-loading"))
+            self._load_analysis(data)
+
             # ── CDF tab (conditional) ───────────────────────────────────
             cdf_enabled = info.properties.get("delta.enableChangeDataFeed") == "true"
             if cdf_enabled:
@@ -463,12 +469,196 @@ class DetailPanel(VerticalScroll):
                 pass
             logger.debug("Transaction log load failed: %s", e)
 
+    @work(group="detail_aux", exclusive=True)
+    async def _load_analysis(self, data: TableNode) -> None:
+        """Load full delta analysis: Summary, Parquet Files, Row Groups, Column Chunks, Columns."""
+        table_data = self._current_table_data
+
+        try:
+            analysis_pane = self.query_one("#tab-analysis", TabPane)
+
+            # Replace loading indicator with a lazy-load button (analysis is expensive)
+            with contextlib.suppress(NoMatches):
+                self.query_one("#analysis-loading").remove()
+
+            if self._current_table_data is not table_data:
+                return
+
+            await analysis_pane.mount(
+                Button("Run Analysis", id="load-analysis", variant="primary")
+            )
+            await analysis_pane.mount(
+                Static(
+                    "[dim]Reads parquet footers for each file — "
+                    "row groups, column chunks, and column stats[/dim]",
+                    classes="detail-section",
+                )
+            )
+
+        except Exception as e:
+            with contextlib.suppress(NoMatches):
+                self.query_one("#analysis-loading").remove()
+            logger.debug("Analysis init failed: %s", e)
+
+    @work(group="detail_aux", exclusive=True)
+    async def _run_analysis(self) -> None:
+        """Execute the full delta analysis after the user clicks 'Run Analysis'."""
+        table_data = self._current_table_data
+        if table_data is None:
+            return
+
+        analysis_pane = self.query_one("#tab-analysis", TabPane)
+
+        # Clear button + description
+        for child in list(analysis_pane.children):
+            child.remove()
+
+        progress_label = Static(
+            "Analysing file 1 of …", id="analysis-progress", classes="detail-section"
+        )
+        await analysis_pane.mount(progress_label)
+
+        async def _progress(current: int, total: int, filename: str) -> None:
+            if self._current_table_data is not table_data:
+                return
+            with contextlib.suppress(NoMatches):
+                self.query_one("#analysis-progress", Static).update(
+                    f"[dim]Analysing file {current} of {total}: {esc(filename)}[/dim]"
+                )
+
+        try:
+            result = await self.client.delta.get_analysis(
+                table_data.workspace,
+                table_data.item_path,
+                table_data.table_name,
+                self.client.dfs,
+                progress_callback=_progress,
+            )
+
+            if self._current_table_data is not table_data:
+                return
+
+            with contextlib.suppress(NoMatches):
+                self.query_one("#analysis-progress").remove()
+
+            s = result.summary
+
+            # ── Summary section ────────────────────────────────────────
+            await analysis_pane.mount(Label("Summary", classes="detail-title"))
+            summary_tbl = DataTable()
+            await analysis_pane.mount(summary_tbl)
+            summary_tbl.add_columns("Metric", "Value")
+            summary_tbl.add_row("Row count", f"{s.row_count:,}")
+            summary_tbl.add_row("Parquet files", f"{s.parquet_files:,}")
+            summary_tbl.add_row("Row groups", f"{s.row_groups:,}")
+            summary_tbl.add_row("Avg rows / row group", f"{s.avg_rows_per_row_group:,.0f}")
+            summary_tbl.add_row("Min rows / row group", f"{s.min_rows_per_row_group:,}")
+            summary_tbl.add_row("Max rows / row group", f"{s.max_rows_per_row_group:,}")
+            summary_tbl.add_row("Total compressed size", _format_size(s.total_compressed_size))
+            if s.files_skipped:
+                summary_tbl.add_row(
+                    "⚠ Files skipped", f"{s.files_skipped} ({esc(s.files_skipped_reason)})"
+                )
+
+            # ── Parquet Files section ─────────────────────────────────
+            if result.parquet_files:
+                await analysis_pane.mount(Label("Parquet Files", classes="detail-title"))
+                pf_tbl = DataTable()
+                await analysis_pane.mount(pf_tbl)
+                pf_tbl.add_columns(
+                    "File", "Row Count", "Row Groups", "Created By"
+                )
+                for pf in result.parquet_files:
+                    pf_tbl.add_row(
+                        esc(pf.parquet_file),
+                        f"{pf.row_count:,}",
+                        str(pf.row_groups),
+                        esc(pf.created_by),
+                    )
+
+            # ── Row Groups section ────────────────────────────────────
+            if result.row_groups:
+                await analysis_pane.mount(Label("Row Groups", classes="detail-title"))
+                rg_tbl = DataTable()
+                await analysis_pane.mount(rg_tbl)
+                rg_tbl.add_columns(
+                    "File", "RG", "Row Count",
+                    "Compressed", "Uncompressed", "Ratio", "% of Rows",
+                )
+                for rg in result.row_groups:
+                    ratio_pct = f"{rg.compression_ratio * 100:.1f}%"
+                    row_pct = f"{rg.ratio_of_total_rows:.2f}%"
+                    rg_tbl.add_row(
+                        esc(rg.parquet_file),
+                        str(rg.row_group_id),
+                        f"{rg.row_count:,}",
+                        _format_size(rg.compressed_size),
+                        _format_size(rg.uncompressed_size),
+                        ratio_pct,
+                        row_pct,
+                    )
+
+            # ── Column Chunks section ─────────────────────────────────
+            if result.column_chunks:
+                await analysis_pane.mount(Label("Column Chunks", classes="detail-title"))
+                cc_tbl = DataTable()
+                await analysis_pane.mount(cc_tbl)
+                cc_tbl.add_columns(
+                    "File", "RG", "Col", "Name", "Type",
+                    "Compressed", "Uncompressed", "Has Dict", "Values", "Encodings",
+                )
+                for cc in result.column_chunks:
+                    cc_tbl.add_row(
+                        esc(cc.parquet_file),
+                        str(cc.row_group_id),
+                        str(cc.column_id),
+                        esc(cc.column_name),
+                        esc(cc.column_type),
+                        _format_size(cc.compressed_size),
+                        _format_size(cc.uncompressed_size),
+                        "✓" if cc.has_dict else "✗",
+                        f"{cc.value_count:,}",
+                        esc(cc.encodings),
+                    )
+
+            # ── Columns section ───────────────────────────────────────
+            if result.columns:
+                await analysis_pane.mount(Label("Columns", classes="detail-title"))
+                col_tbl = DataTable()
+                await analysis_pane.mount(col_tbl)
+                col_tbl.add_columns(
+                    "Column", "Type", "Compressed", "Uncompressed", "% of Table"
+                )
+                for col in result.columns:
+                    col_tbl.add_row(
+                        esc(col.column_name),
+                        esc(col.column_type),
+                        _format_size(col.compressed_size),
+                        _format_size(col.uncompressed_size),
+                        f"{col.size_percent_of_table:.1f}%",
+                    )
+
+        except Exception as e:
+            with contextlib.suppress(NoMatches):
+                self.query_one("#analysis-progress").remove()
+            try:
+                await analysis_pane.mount(
+                    Static(
+                        f"❌ Analysis failed: {esc(str(e))}", classes="detail-section"
+                    )
+                )
+            except Exception:
+                pass
+            logger.debug("Analysis run failed: %s", e)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle lazy-load buttons in delta table tabs."""
         if event.button.id == "load-data-preview":
             self._load_data_preview()
         elif event.button.id == "load-cdf-preview":
             self._load_cdf_preview()
+        elif event.button.id == "load-analysis":
+            self._run_analysis()
 
     @work(group="detail_aux", exclusive=True)
     async def _load_data_preview(self) -> None:


### PR DESCRIPTION
…nk and column stats

Mirrors the 5-view structure from semantic-link-labs delta_analyzer:
- Summary: row count, file count, row groups, avg/min/max rows per RG, total size
- Parquet Files: per-file row count, row groups, created_by
- Row Groups: compressed/uncompressed size, compression ratio, % of total rows
- Column Chunks: per-column type, sizes, dict pages, value count, encodings
- Columns: aggregated compressed/uncompressed size and % of table per column

Implementation details:
- DfsClient.read_file_tail: HTTP Range tail read for efficient parquet footer fetching
- DeltaTableReader.get_analysis: reads parquet footers (no full file downloads), falls back to full read if footer overflows tail buffer
- 6 new Pydantic models: ParquetFileInfo, RowGroupInfo, ColumnChunkInfo, ColumnInfo, DeltaAnalysisSummary, DeltaAnalysisResult
- Analysis tab is lazy-loaded via 'Run Analysis' button (same UX as Data/CDF tabs)
- Live per-file progress label during analysis

## Description

Brief summary of the changes and motivation.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [ ] Tests added or updated
- [ ] `uv run pytest` passes
- [ ] `uv run ruff check src/ tests/` passes
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Documentation updated (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Delta table analysis: per-file stats, row-group and column-chunk metrics, compression ratios, and aggregated summaries.
  * Added an "Analysis" tab in the Delta table detail view with a Run Analysis workflow, progress reporting, and error handling.
  * Enhanced table metadata and exports to surface richer analysis results for display and download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->