### PR TITLE
fix: Column.metadata type should be dict[str, Any] (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `Column.metadata` type changed from `dict[str, str]` to `dict[str, Any]` — Delta column mapping stores non-string metadata values (e.g. `delta.columnMapping.id` is an int) (#25)
 - Data preview crash on Delta tables with nanosecond-precision timestamps — `timestamp[ns]` columns are now safely downcast to `timestamp[us]` with sub-microsecond precision truncated; timestamps outside year 0001–9999 are defensively nullified (#19)
 
 ## [0.3.0] - 2026-04-20

--- a/TUI/src/onelake_client/models/table.py
+++ b/TUI/src/onelake_client/models/table.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel
 
 
@@ -7,7 +9,7 @@ class Column(BaseModel):
     name: str
     type: str
     nullable: bool = True
-    metadata: dict[str, str] | None = None
+    metadata: dict[str, Any] | None = None
     comment: str | None = None
 
 

--- a/TUI/tests/test_models.py
+++ b/TUI/tests/test_models.py
@@ -60,6 +60,21 @@ def test_path_info_string_coercion():
     assert pi.content_length == 100
 
 
+def test_column_metadata_non_string_values():
+    """Non-string metadata values (int, bool, nested dict) round-trip correctly (#25)."""
+    meta = {
+        "delta.columnMapping.id": 42,
+        "delta.columnMapping.physicalName": "col-abc-123",
+        "delta.generationExpression.enabled": True,
+        "custom.nested": {"key": "value"},
+    }
+    col = Column(name="sensor_id", type="long", metadata=meta)
+    assert col.metadata["delta.columnMapping.id"] == 42
+    assert col.metadata["delta.generationExpression.enabled"] is True
+    assert col.metadata["custom.nested"] == {"key": "value"}
+    assert col.metadata["delta.columnMapping.physicalName"] == "col-abc-123"
+
+
 def test_delta_table_info():
     info = DeltaTableInfo(
         name="customers",

--- a/TUI/tests/test_models.py
+++ b/TUI/tests/test_models.py
@@ -74,6 +74,18 @@ def test_column_metadata_non_string_values():
     assert col.metadata["custom.nested"] == {"key": "value"}
     assert col.metadata["delta.columnMapping.physicalName"] == "col-abc-123"
 
+    # Round-trip via dict serialization
+    col2 = Column.model_validate(col.model_dump())
+    assert col2.metadata["delta.columnMapping.id"] == 42
+    assert col2.metadata["delta.generationExpression.enabled"] is True
+    assert col2.metadata["custom.nested"] == {"key": "value"}
+
+    # Round-trip via JSON serialization
+    col3 = Column.model_validate_json(col.model_dump_json())
+    assert col3.metadata["delta.columnMapping.id"] == 42
+    assert col3.metadata["delta.generationExpression.enabled"] is True
+    assert col3.metadata["custom.nested"] == {"key": "value"}
+
 
 def test_delta_table_info():
     info = DeltaTableInfo(


### PR DESCRIPTION
## Problem

`Column.metadata` is typed as `dict[str, str] | None` but Delta column mapping stores non-string metadata values (e.g. `delta.columnMapping.id` is an integer). Discovered in #21.

## Changes

- Changed `Column.metadata` from `dict[str, str] | None` to `dict[str, Any] | None` in `onelake_client/models/table.py`
- Added `from typing import Any` import (before pydantic import per ruff isort)
- Added test confirming non-string metadata values (int, bool, nested dict) round-trip correctly
- Updated CHANGELOG

## Verification

- No downstream code in `detail.py` assumes string-only metadata values (Schema tab only reads `col.name`, `col.type`, `col.nullable`)

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved column metadata flexibility to support non-string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->